### PR TITLE
SLLS-23 Code action to investigate taint vulnerability on the originating server

### DIFF
--- a/src/main/java/org/sonarsource/sonarlint/ls/AnalysisManager.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/AnalysisManager.java
@@ -82,6 +82,7 @@ import static java.util.Collections.singleton;
 import static java.util.Optional.empty;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.joining;
+import static org.sonarsource.sonarlint.ls.Utils.pluralize;
 
 public class AnalysisManager implements WorkspaceSettingsChangeListener {
 
@@ -282,7 +283,8 @@ public class AnalysisManager implements WorkspaceSettingsChangeListener {
 
     // Check if file has not being closed during the analysis
     if (fileContentPerFileURI.containsKey(fileUri)) {
-      LOG.info("Found {} issue(s)", newIssues.size());
+      int foundIssues = newIssues.size();
+      LOG.info("Found {} {}", foundIssues, pluralize(foundIssues, "issue"));
       client.publishDiagnostics(newPublishDiagnostics(fileUri));
     }
   }
@@ -398,7 +400,8 @@ public class AnalysisManager implements WorkspaceSettingsChangeListener {
         serverIssueTracker.matchAndTrack(filePath, issues, issueListener, shouldFetchServerIssues);
         List<ServerIssue> serverIssues = engine.getServerIssues(binding.getBinding(), filePath);
         if (!serverIssues.isEmpty()) {
-          LOG.info("Fetched {} vulnerabilities from {}", serverIssues.size(), binding.getConnectionId());
+          int fetchedIssues = serverIssues.size();
+          LOG.info("Fetched {} {} from {}", fetchedIssues, pluralize(fetchedIssues, "vulnerability", "vulnerabilities"), binding.getConnectionId());
         }
         taintVulnerabilitiesPerFile.put(uri, serverIssues.stream()
           .filter(it -> it.ruleKey().contains(SECURITY_REPOSITORY_HINT))
@@ -526,10 +529,6 @@ public class AnalysisManager implements WorkspaceSettingsChangeListener {
 
   private static String buildMessageWithPluralizedSuffix(@Nullable String issueMessage, long nbItems, String itemName) {
     return String.format(MESSAGE_WITH_PLURALIZED_SUFFIX, issueMessage, nbItems, pluralize(nbItems, itemName));
-  }
-
-  private static String pluralize(long nbItems, String itemName) {
-    return nbItems > 1 ? (itemName + "s") : itemName;
   }
 
   private PublishDiagnosticsParams newPublishDiagnostics(URI newUri) {

--- a/src/main/java/org/sonarsource/sonarlint/ls/AnalysisManager.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/AnalysisManager.java
@@ -397,6 +397,9 @@ public class AnalysisManager implements WorkspaceSettingsChangeListener {
         ServerIssueTrackerWrapper serverIssueTracker = binding.getServerIssueTracker();
         serverIssueTracker.matchAndTrack(filePath, issues, issueListener, shouldFetchServerIssues);
         List<ServerIssue> serverIssues = engine.getServerIssues(binding.getBinding(), filePath);
+        if (!serverIssues.isEmpty()) {
+          LOG.info("Fetched {} vulnerabilities from {}", serverIssues.size(), binding.getConnectionId());
+        }
         taintVulnerabilitiesPerFile.put(uri, serverIssues.stream()
           .filter(it -> it.ruleKey().contains(SECURITY_REPOSITORY_HINT))
           .filter(it -> it.resolution().isEmpty())

--- a/src/main/java/org/sonarsource/sonarlint/ls/AnalysisManager.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/AnalysisManager.java
@@ -323,6 +323,13 @@ public class AnalysisManager implements WorkspaceSettingsChangeListener {
       .findFirst();
   }
 
+  Optional<ServerIssue> getTaintVulnerabilityByKey(String issueId) {
+    return taintVulnerabilitiesPerFile.values().stream()
+      .flatMap(List::stream)
+      .filter(i -> issueId.equals(i.key()))
+      .findFirst();
+  }
+
   static boolean locationMatches(Issue i, Diagnostic d) {
     return position(i).equals(d.getRange());
   }

--- a/src/main/java/org/sonarsource/sonarlint/ls/CommandManager.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/CommandManager.java
@@ -46,6 +46,7 @@ import org.sonarsource.sonarlint.core.client.api.connected.ConnectedRuleDetails;
 import org.sonarsource.sonarlint.core.client.api.connected.ConnectedSonarLintEngine;
 import org.sonarsource.sonarlint.core.client.api.standalone.StandaloneRuleDetails;
 import org.sonarsource.sonarlint.core.client.api.standalone.StandaloneRuleParam;
+import org.sonarsource.sonarlint.core.util.StringUtils;
 import org.sonarsource.sonarlint.ls.SonarLintExtendedLanguageClient.ShowRuleDescriptionParams;
 import org.sonarsource.sonarlint.ls.commands.ShowAllLocationsCommand;
 import org.sonarsource.sonarlint.ls.connected.ProjectBindingManager;
@@ -120,7 +121,7 @@ public class CommandManager {
           }
           String title = String.format("Open taint vulnerability '%s' on '%s'", ruleKey, actualBinding.getConnectionId());
           String serverUrl = settingsManager.getCurrentSettings().getServerConnections().get(actualBinding.getConnectionId()).getServerUrl();
-          String projectKey = Utils.encodeUriComponent(actualBinding.getBinding().projectKey());
+          String projectKey = StringUtils.urlEncode(actualBinding.getBinding().projectKey());
           String issueUrl = String.format("%s/project/issues?id=%s&issues=%s&open=%s", serverUrl, projectKey, issue.key(), issue.key());
           codeActions.add(newQuickFix(d, title, SONARLINT_BROWSE_TAINT_VULNERABILITY, Collections.singletonList(issueUrl)));
         });

--- a/src/main/java/org/sonarsource/sonarlint/ls/CommandManager.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/CommandManager.java
@@ -85,8 +85,7 @@ public class CommandManager {
       if (SONARLINT_SOURCE.equals(d.getSource())) {
         String ruleKey = d.getCode().getLeft();
         cancelToken.checkCanceled();
-        String titleShowRuleDesc = String.format("Open description of SonarLint rule '%s'", ruleKey);
-        codeActions.add(newQuickFix(d, titleShowRuleDesc, SONARLINT_OPEN_RULE_DESCRIPTION_FROM_CODE_ACTION_COMMAND, Arrays.asList(ruleKey, params.getTextDocument().getUri())));
+        addRuleDescriptionCodeAction(params, codeActions, d, ruleKey);
         analysisManager.getIssueForDiagnostic(uri, d).ifPresent(issue -> {
           if (! issue.flows().isEmpty()) {
             String titleShowAllLocations = String.format("Show all locations for issue '%s'", ruleKey);
@@ -98,6 +97,7 @@ public class CommandManager {
           codeActions.add(newQuickFix(d, titleDeactivate, SONARLINT_DEACTIVATE_RULE_COMMAND, Collections.singletonList(ruleKey)));
         }
       } else if (SONARQUBE_TAINT_SOURCE.equals(d.getSource())) {
+        addRuleDescriptionCodeAction(params, codeActions, d, d.getCode().getLeft());
         analysisManager.getTaintVulnerabilityForDiagnostic(uri, d).ifPresent(issue -> {
           if (!issue.getFlows().isEmpty()) {
             String titleShowAllLocations = String.format("Show all locations for taint vulnerability '%s'", issue.ruleKey());
@@ -109,6 +109,11 @@ public class CommandManager {
       }
     }
     return codeActions;
+  }
+
+  private static void addRuleDescriptionCodeAction(CodeActionParams params, List<Either<Command, CodeAction>> codeActions, Diagnostic d, String ruleKey) {
+    String titleShowRuleDesc = String.format("Open description of SonarLint rule '%s'", ruleKey);
+    codeActions.add(newQuickFix(d, titleShowRuleDesc, SONARLINT_OPEN_RULE_DESCRIPTION_FROM_CODE_ACTION_COMMAND, Arrays.asList(ruleKey, params.getTextDocument().getUri())));
   }
 
   private static Either<Command, CodeAction> newQuickFix(Diagnostic diag, String title, String command, List<Object> params) {

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintExtendedLanguageClient.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintExtendedLanguageClient.java
@@ -30,6 +30,7 @@ import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.sonarsource.sonarlint.core.client.api.standalone.StandaloneRuleParam;
 import org.sonarsource.sonarlint.core.serverapi.hotspot.ServerHotspot;
+import org.sonarsource.sonarlint.ls.commands.ShowAllLocationsCommand;
 
 public interface SonarLintExtendedLanguageClient extends LanguageClient {
 
@@ -50,6 +51,9 @@ public interface SonarLintExtendedLanguageClient extends LanguageClient {
 
   @JsonRequest("sonarlint/showHotspot")
   CompletableFuture<Void> showHotspot(ServerHotspot hotspot);
+
+  @JsonRequest("sonarlint/showTaintVulnerability")
+  CompletableFuture<Void> showTaintVulnerability(ShowAllLocationsCommand.Param params);
 
   class ShowRuleDescriptionParams {
     @Expose

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
@@ -136,8 +136,8 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
     this.analysisManager = new AnalysisManager(lsLogOutput, enginesFactory, client, telemetry, workspaceFoldersManager, settingsManager, bindingManager);
     bindingManager.setAnalysisManager(analysisManager);
     this.settingsManager.addListener(analysisManager);
-    this.commandManager = new CommandManager(client, bindingManager, analysisManager);
-    this.securityHotspotsHandlerServer = new SecurityHotspotsHandlerServer(lsLogOutput, bindingManager, client, this.telemetry);
+    this.commandManager = new CommandManager(client, settingsManager, bindingManager, analysisManager, telemetry);
+    this.securityHotspotsHandlerServer = new SecurityHotspotsHandlerServer(lsLogOutput, bindingManager, client, telemetry);
     launcher.startListening();
   }
 

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintTelemetry.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintTelemetry.java
@@ -189,6 +189,18 @@ public class SonarLintTelemetry implements WorkspaceSettingsChangeListener {
     }
   }
 
+  public void taintVulnerabilitiesInvestigatedLocally() {
+    if(enabled()) {
+      telemetry.taintVulnerabilitiesInvestigatedLocally();
+    }
+  }
+
+  public void taintVulnerabilitiesInvestigatedRemotely() {
+    if(enabled()) {
+      telemetry.taintVulnerabilitiesInvestigatedRemotely();
+    }
+  }
+
   public void stop() {
     if (enabled()) {
       telemetry.stop();

--- a/src/main/java/org/sonarsource/sonarlint/ls/Utils.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/Utils.java
@@ -66,15 +66,6 @@ public class Utils {
     Thread.currentThread().interrupt();
   }
 
-  public static String encodeUriComponent(String toEncode) {
-    try {
-      return URLEncoder.encode(toEncode, StandardCharsets.UTF_8.name());
-    } catch (UnsupportedEncodingException e) {
-      // Should not happen on a standard JVM
-      throw new IllegalStateException(e);
-    }
-  }
-
   public static String pluralize(long nbItems, String itemName) {
     return pluralize(nbItems, itemName, itemName + "s");
   }

--- a/src/main/java/org/sonarsource/sonarlint/ls/Utils.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/Utils.java
@@ -74,4 +74,12 @@ public class Utils {
       throw new IllegalStateException(e);
     }
   }
+
+  public static String pluralize(long nbItems, String itemName) {
+    return pluralize(nbItems, itemName, itemName + "s");
+  }
+
+  public static String pluralize(long nbItems, String singular, String plural) {
+    return nbItems == 1 ? singular : plural;
+  }
 }

--- a/src/main/java/org/sonarsource/sonarlint/ls/Utils.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/Utils.java
@@ -22,6 +22,9 @@ package org.sonarsource.sonarlint.ls;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonSyntaxException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.ThreadFactory;
 import javax.annotation.CheckForNull;
@@ -61,5 +64,14 @@ public class Utils {
   public static void interrupted(InterruptedException e) {
     LOG.debug("Interrupted!", e);
     Thread.currentThread().interrupt();
+  }
+
+  public static String encodeUriComponent(String toEncode) {
+    try {
+      return URLEncoder.encode(toEncode, StandardCharsets.UTF_8.name());
+    } catch (UnsupportedEncodingException e) {
+      // Should not happen on a standard JVM
+      throw new IllegalStateException(e);
+    }
   }
 }

--- a/src/main/java/org/sonarsource/sonarlint/ls/commands/ShowAllLocationsCommand.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/commands/ShowAllLocationsCommand.java
@@ -47,7 +47,7 @@ public final class ShowAllLocationsCommand {
     // NOP
   }
 
-  static class Param {
+  public static class Param {
     private final URI fileUri;
     private final String message;
     private final String severity;

--- a/src/main/java/org/sonarsource/sonarlint/ls/commands/ShowAllLocationsCommand.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/commands/ShowAllLocationsCommand.java
@@ -53,6 +53,7 @@ public final class ShowAllLocationsCommand {
     private final String severity;
     private final String ruleKey;
     private final List<Flow> flows;
+    private final String connectionId;
     private final String creationDate;
 
     private Param(Issue issue) {
@@ -61,16 +62,18 @@ public final class ShowAllLocationsCommand {
       this.severity = issue.getSeverity();
       this.ruleKey = issue.getRuleKey();
       this.flows = issue.flows().stream().map(Flow::new).collect(Collectors.toList());
+      this.connectionId = null;
       this.creationDate = null;
     }
 
     @VisibleForTesting
-    Param(ServerIssue issue, Function<String, Optional<URI>> pathResolver, Map<URI, LocalCodeFile> localFileCache) {
+    Param(ServerIssue issue, String connectionId, Function<String, Optional<URI>> pathResolver, Map<URI, LocalCodeFile> localFileCache) {
       this.fileUri = pathResolver.apply(issue.getFilePath()).orElse(null);
       this.message = issue.getMessage();
       this.severity = issue.severity();
       this.ruleKey = issue.ruleKey();
       this.flows = issue.getFlows().stream().map(f -> new Flow(f, pathResolver, localFileCache)).collect(Collectors.toList());
+      this.connectionId = connectionId;
       this.creationDate = DateTimeFormatter.ISO_DATE_TIME.format(issue.creationDate().atOffset(ZoneOffset.UTC));
     }
 
@@ -88,6 +91,11 @@ public final class ShowAllLocationsCommand {
 
     public String getRuleKey() {
       return ruleKey;
+    }
+
+    @CheckForNull
+    public String getConnectionId() {
+      return connectionId;
     }
 
     @CheckForNull
@@ -183,8 +191,8 @@ public final class ShowAllLocationsCommand {
     return new Param(issue);
   }
 
-  public static Param params(ServerIssue issue, Function<String, Optional<URI>> pathResolver) {
-    return new Param(issue, pathResolver, new HashMap<>());
+  public static Param params(ServerIssue issue, String connectionId, Function<String, Optional<URI>> pathResolver) {
+    return new Param(issue, connectionId, pathResolver, new HashMap<>());
   }
 
   @CheckForNull

--- a/src/main/java/org/sonarsource/sonarlint/ls/commands/ShowAllLocationsCommand.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/commands/ShowAllLocationsCommand.java
@@ -21,6 +21,8 @@ package org.sonarsource.sonarlint.ls.commands;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.net.URI;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +53,7 @@ public final class ShowAllLocationsCommand {
     private final String severity;
     private final String ruleKey;
     private final List<Flow> flows;
+    private final String creationDate;
 
     private Param(Issue issue) {
       this.fileUri = nullableUri(issue.getInputFile());
@@ -58,6 +61,7 @@ public final class ShowAllLocationsCommand {
       this.severity = issue.getSeverity();
       this.ruleKey = issue.getRuleKey();
       this.flows = issue.flows().stream().map(Flow::new).collect(Collectors.toList());
+      this.creationDate = null;
     }
 
     @VisibleForTesting
@@ -67,6 +71,7 @@ public final class ShowAllLocationsCommand {
       this.severity = issue.severity();
       this.ruleKey = issue.ruleKey();
       this.flows = issue.getFlows().stream().map(f -> new Flow(f, pathResolver, localFileCache)).collect(Collectors.toList());
+      this.creationDate = DateTimeFormatter.ISO_DATE_TIME.format(issue.creationDate().atOffset(ZoneOffset.UTC));
     }
 
     public URI getFileUri() {
@@ -83,6 +88,11 @@ public final class ShowAllLocationsCommand {
 
     public String getRuleKey() {
       return ruleKey;
+    }
+
+    @CheckForNull
+    public String getCreationDate() {
+      return creationDate;
     }
 
     public List<Flow> getFlows() {

--- a/src/main/java/org/sonarsource/sonarlint/ls/connected/ProjectBindingManager.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/connected/ProjectBindingManager.java
@@ -496,7 +496,6 @@ public class ProjectBindingManager implements WorkspaceSettingsChangeListener, W
   }
 
   private static Optional<File> tryResolveLocalFile(String serverPath, URI folderUri, ProjectBindingWrapper binding) {
-    LOG.info("Server path: " + serverPath + " Folder URI: " + folderUri);
     return binding.getBinding()
       .serverPathToIdePath(serverPath)
       // Try to resolve local path in matching folder

--- a/src/test/java/org/sonarsource/sonarlint/ls/AnalysisManagerTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/AnalysisManagerTests.java
@@ -20,6 +20,7 @@
 package org.sonarsource.sonarlint.ls;
 
 import java.net.URI;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sonarsource.sonarlint.core.client.api.common.analysis.Issue;
 import org.sonarsource.sonarlint.core.client.api.connected.ServerIssue;
+import org.sonarsource.sonarlint.core.client.api.connected.ServerIssueLocation;
 import org.sonarsource.sonarlint.ls.connected.ProjectBindingManager;
 import org.sonarsource.sonarlint.ls.folders.WorkspaceFoldersManager;
 import org.sonarsource.sonarlint.ls.log.LanguageClientLogOutput;
@@ -85,6 +87,9 @@ class AnalysisManagerTests {
   void testIssueConversion() {
     ServerIssue issue = mock(ServerIssue.class);
     ServerIssue.Flow flow = mock(ServerIssue.Flow.class);
+    ServerIssueLocation loc1 = mock(ServerIssueLocation.class);
+    ServerIssueLocation loc2 = mock(ServerIssueLocation.class);
+    when(flow.locations()).thenReturn(Arrays.asList(loc1, loc2));
     when(issue.getStartLine()).thenReturn(1);
     when(issue.severity()).thenReturn("BLOCKER");
     when(issue.ruleKey()).thenReturn("ruleKey");
@@ -93,7 +98,7 @@ class AnalysisManagerTests {
 
     Diagnostic diagnostic = convert(issue).get();
 
-    assertThat(diagnostic.getMessage()).isEqualTo("message [+1 flow]");
+    assertThat(diagnostic.getMessage()).isEqualTo("message [+2 locations]");
     assertThat(diagnostic.getSeverity()).isEqualTo(DiagnosticSeverity.Error);
     assertThat(diagnostic.getSource()).isEqualTo("SonarQube Taint Analyzer");
     assertThat(diagnostic.getCode().getLeft()).isEqualTo("ruleKey");

--- a/src/test/java/org/sonarsource/sonarlint/ls/AnalysisManagerTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/AnalysisManagerTests.java
@@ -115,10 +115,20 @@ class AnalysisManagerTests {
     when(issue.ruleKey()).thenReturn("ruleKey");
     taintVulnerabilitiesPerFile.put(uri, Collections.singletonList(issue));
 
-    Optional<ServerIssue> serverIssue = underTest.getTaintVulnerabilityForDiagnostic(uri, diagnostic);
-
-    assertThat(serverIssue).contains(issue);
+    assertThat(underTest.getTaintVulnerabilityForDiagnostic(uri, diagnostic)).hasValue(issue);
   }
 
+  @Test
+  void testGetServerIssueByKey() throws Exception {
+    URI uri = new URI("/");
+    ServerIssue issue = mock(ServerIssue.class);
+    String issueKey = "key";
+    when(issue.key()).thenReturn(issueKey);
+
+    taintVulnerabilitiesPerFile.put(uri, Collections.singletonList(issue));
+
+    assertThat(underTest.getTaintVulnerabilityByKey(issueKey)).hasValue(issue);
+    assertThat(underTest.getTaintVulnerabilityByKey("otherKey")).isEmpty();
+  }
 
 }

--- a/src/test/java/org/sonarsource/sonarlint/ls/CommandManagerTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/CommandManagerTests.java
@@ -73,6 +73,7 @@ import static org.sonarsource.sonarlint.ls.AnalysisManager.SONARLINT_SOURCE;
 import static org.sonarsource.sonarlint.ls.AnalysisManager.SONARQUBE_TAINT_SOURCE;
 import static org.sonarsource.sonarlint.ls.CommandManager.SONARLINT_BROWSE_TAINT_VULNERABILITY;
 import static org.sonarsource.sonarlint.ls.CommandManager.SONARLINT_OPEN_RULE_DESCRIPTION_FROM_CODE_ACTION_COMMAND;
+import static org.sonarsource.sonarlint.ls.CommandManager.SONARLINT_SHOW_TAINT_VULNERABILITY_FLOWS;
 import static org.sonarsource.sonarlint.ls.CommandManager.SONARLINT_UPDATE_ALL_BINDINGS_COMMAND;
 import static org.sonarsource.sonarlint.ls.CommandManager.getHtmlDescription;
 
@@ -277,5 +278,22 @@ class CommandManagerTests {
     underTest.executeCommand(new ExecuteCommandParams(SONARLINT_BROWSE_TAINT_VULNERABILITY, singletonList(new JsonPrimitive(issueUrl))), NOP_CANCEL_TOKEN);
     verify(mockTelemetry).taintVulnerabilitiesInvestigatedRemotely();
     verify(mockClient).browseTo(issueUrl);
+  }
+
+  @Test
+  void showTaintVulnerabilityFlows() {
+    String issueKey = "someIssueKey";
+    ServerIssue issue = mock(ServerIssue.class);
+    when(issue.ruleKey()).thenReturn("ruleKey");
+    when(issue.creationDate()).thenReturn(Instant.EPOCH);
+    ServerIssue.Flow flow = mock(ServerIssue.Flow.class);
+    when(issue.getFlows()).thenReturn(Collections.singletonList(flow));
+    ServerIssueLocation location = mock(ServerIssueLocation.class);
+    when(flow.locations()).thenReturn(Collections.singletonList(location));
+    when(mockAnalysisManager.getTaintVulnerabilityByKey(issueKey)).thenReturn(Optional.of(issue));
+
+    underTest.executeCommand(new ExecuteCommandParams(SONARLINT_SHOW_TAINT_VULNERABILITY_FLOWS, singletonList(new JsonPrimitive(issueKey))), NOP_CANCEL_TOKEN);
+    verify(mockAnalysisManager).getTaintVulnerabilityByKey(issueKey);
+    verify(mockTelemetry).taintVulnerabilitiesInvestigatedLocally();
   }
 }

--- a/src/test/java/org/sonarsource/sonarlint/ls/CommandManagerTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/CommandManagerTests.java
@@ -283,6 +283,7 @@ class CommandManagerTests {
   @Test
   void showTaintVulnerabilityFlows() {
     String issueKey = "someIssueKey";
+    String connectionId = "connectionId";
     ServerIssue issue = mock(ServerIssue.class);
     when(issue.ruleKey()).thenReturn("ruleKey");
     when(issue.creationDate()).thenReturn(Instant.EPOCH);
@@ -292,7 +293,8 @@ class CommandManagerTests {
     when(flow.locations()).thenReturn(Collections.singletonList(location));
     when(mockAnalysisManager.getTaintVulnerabilityByKey(issueKey)).thenReturn(Optional.of(issue));
 
-    underTest.executeCommand(new ExecuteCommandParams(SONARLINT_SHOW_TAINT_VULNERABILITY_FLOWS, singletonList(new JsonPrimitive(issueKey))), NOP_CANCEL_TOKEN);
+    underTest.executeCommand(new ExecuteCommandParams(SONARLINT_SHOW_TAINT_VULNERABILITY_FLOWS, asList(new JsonPrimitive(issueKey), new JsonPrimitive(connectionId))),
+      NOP_CANCEL_TOKEN);
     verify(mockAnalysisManager).getTaintVulnerabilityByKey(issueKey);
     verify(mockTelemetry).taintVulnerabilitiesInvestigatedLocally();
   }

--- a/src/test/java/org/sonarsource/sonarlint/ls/CommandManagerTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/CommandManagerTests.java
@@ -176,9 +176,11 @@ class CommandManagerTests {
     List<Either<Command, CodeAction>> codeActions = underTest.computeCodeActions(new CodeActionParams(FAKE_TEXT_DOCUMENT, FAKE_RANGE,
       new CodeActionContext(singletonList(d))), NOP_CANCEL_TOKEN);
 
-    assertThat(codeActions).extracting(c -> c.getRight().getTitle()).containsOnly("Show all locations for taint vulnerability 'ruleKey'");
+    assertThat(codeActions).extracting(c -> c.getRight().getTitle()).containsOnly(
+      "Open description of SonarLint rule 'XYZ'",
+      "Show all locations for taint vulnerability 'ruleKey'"
+    );
   }
-
 
   @Test
   void suggestShowAllLocationsForIssueWithFlows() {

--- a/src/test/java/org/sonarsource/sonarlint/ls/CommandManagerTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/CommandManagerTests.java
@@ -21,6 +21,7 @@ package org.sonarsource.sonarlint.ls;
 
 import com.google.gson.JsonPrimitive;
 import java.net.URI;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -165,6 +166,7 @@ class CommandManagerTests {
 
     ServerIssue issue = mock(ServerIssue.class);
     when(issue.ruleKey()).thenReturn("ruleKey");
+    when(issue.creationDate()).thenReturn(Instant.EPOCH);
     ServerIssue.Flow flow = mock(ServerIssue.Flow.class);
     when(issue.getFlows()).thenReturn(Collections.singletonList(flow));
     ServerIssueLocation location = mock(ServerIssueLocation.class);

--- a/src/test/java/org/sonarsource/sonarlint/ls/SonarLintTelemetryTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/SonarLintTelemetryTests.java
@@ -229,6 +229,38 @@ class SonarLintTelemetryTests {
   }
 
   @Test
+  void taintVulnerabilitiesInvestigatedLocally_when_enabled() {
+    when(telemetryManager.isEnabled()).thenReturn(true);
+    telemetry.taintVulnerabilitiesInvestigatedLocally();
+    verify(telemetryManager).isEnabled();
+    verify(telemetryManager).taintVulnerabilitiesInvestigatedLocally();
+  }
+
+  @Test
+  void taintVulnerabilitiesInvestigatedLocally_when_disabled() {
+    when(telemetryManager.isEnabled()).thenReturn(false);
+    telemetry.taintVulnerabilitiesInvestigatedLocally();
+    verify(telemetryManager).isEnabled();
+    verifyNoMoreInteractions(telemetryManager);
+  }
+
+  @Test
+  void taintVulnerabilitiesInvestigatedRemotely_when_enabled() {
+    when(telemetryManager.isEnabled()).thenReturn(true);
+    telemetry.taintVulnerabilitiesInvestigatedRemotely();
+    verify(telemetryManager).isEnabled();
+    verify(telemetryManager).taintVulnerabilitiesInvestigatedRemotely();
+  }
+
+  @Test
+  void taintVulnerabilitiesInvestigatedRemotely_when_disabled() {
+    when(telemetryManager.isEnabled()).thenReturn(false);
+    telemetry.taintVulnerabilitiesInvestigatedRemotely();
+    verify(telemetryManager).isEnabled();
+    verifyNoMoreInteractions(telemetryManager);
+  }
+
+  @Test
   void should_start_disabled_when_storagePath_null() {
     when(telemetryManager.isEnabled()).thenReturn(true);
     SonarLintTelemetry telemetry = new SonarLintTelemetry(mock(ApacheHttpClient.class)) {

--- a/src/test/java/org/sonarsource/sonarlint/ls/UtilsTest.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/UtilsTest.java
@@ -1,0 +1,48 @@
+/*
+ * SonarLint Language Server
+ * Copyright (C) 2009-2021 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.ls;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UtilsTest {
+
+  @ParameterizedTest
+  @CsvSource({
+    "0,vulnerabilities",
+    "1,vulnerability",
+    "42,vulnerabilities"
+  })
+  void shouldPluralizeVulnerability(long nbItems, String expected) {
+    assertThat(Utils.pluralize(nbItems, "vulnerability", "vulnerabilities")).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "0,issues",
+    "1,issue",
+    "42,issues"
+  })
+  void shouldPluralizeIssue(long nbItems, String expected) {
+    assertThat(Utils.pluralize(nbItems, "issue")).isEqualTo(expected);
+  }
+}

--- a/src/test/java/org/sonarsource/sonarlint/ls/commands/ShowAllLocationsCommandTest.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/commands/ShowAllLocationsCommandTest.java
@@ -85,6 +85,8 @@ class ShowAllLocationsCommandTest {
     assertThat(params.getFlows()).hasSize(2);
     assertThat(params.getFlows().get(0).getLocations()).hasSize(2);
     assertThat(params.getFlows().get(1).getLocations()).hasSize(1);
+    assertThat(params.getConnectionId()).isNull();
+    assertThat(params.getCreationDate()).isNull();
   }
 
   @Test
@@ -117,14 +119,11 @@ class ShowAllLocationsCommandTest {
     Map<URI, LocalCodeFile> cache = new HashMap<>();
     cache.put(Paths.get(locationFilePath).toUri(), mockCodeFile);
 
-    ShowAllLocationsCommand.Param param = new ShowAllLocationsCommand.Param(issue, (s) -> {
-      try {
-        return Optional.of(Paths.get(s).toUri());
-      } catch (InvalidPathException e) {
-        return Optional.empty();
-      }
-    }, cache);
+    String connectionId = "connectionId";
 
+    ShowAllLocationsCommand.Param param = new ShowAllLocationsCommand.Param(issue, connectionId, ShowAllLocationsCommandTest::resolvePath, cache);
+
+    assertThat(param.getConnectionId()).isEqualTo(connectionId);
     assertThat(param.getCreationDate()).isEqualTo("1970-01-01T00:00:00Z");
     assertThat(param.getFileUri().toString()).endsWith("filePath");
     List<ShowAllLocationsCommand.Location> allLocations = param.getFlows().get(0).getLocations();
@@ -141,4 +140,11 @@ class ShowAllLocationsCommandTest {
     assertThat(secondLocation.getCodeMatches()).isFalse();
   }
 
+  private static Optional<URI> resolvePath(String s) {
+    try {
+      return Optional.of(Paths.get(s).toUri());
+    } catch (InvalidPathException e) {
+      return Optional.empty();
+    }
+  }
 }

--- a/src/test/java/org/sonarsource/sonarlint/ls/commands/ShowAllLocationsCommandTest.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/commands/ShowAllLocationsCommandTest.java
@@ -22,6 +22,7 @@ package org.sonarsource.sonarlint.ls.commands;
 import java.net.URI;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -92,6 +93,7 @@ class ShowAllLocationsCommandTest {
     when(issue.getFilePath()).thenReturn("filePath");
     ServerIssue.Flow flow = mock(ServerIssue.Flow.class);
     when(issue.getFlows()).thenReturn(Collections.singletonList(flow));
+    when(issue.creationDate()).thenReturn(Instant.EPOCH);
 
     String locationFilePath = "locationFilePath";
 
@@ -123,6 +125,7 @@ class ShowAllLocationsCommandTest {
       }
     }, cache);
 
+    assertThat(param.getCreationDate()).isEqualTo("1970-01-01T00:00:00Z");
     assertThat(param.getFileUri().toString()).endsWith("filePath");
     List<ShowAllLocationsCommand.Location> allLocations = param.getFlows().get(0).getLocations();
     ShowAllLocationsCommand.Location firstLocation = allLocations.get(0);

--- a/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/AbstractLanguageServerMediumTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/AbstractLanguageServerMediumTests.java
@@ -86,6 +86,7 @@ import org.sonarsource.sonarlint.ls.ServerMain;
 import org.sonarsource.sonarlint.ls.SonarLintExtendedLanguageClient;
 import org.sonarsource.sonarlint.ls.SonarLintExtendedLanguageServer;
 import org.sonarsource.sonarlint.ls.SonarLintTelemetry;
+import org.sonarsource.sonarlint.ls.commands.ShowAllLocationsCommand;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -332,6 +333,11 @@ abstract class AbstractLanguageServerMediumTests {
 
     @Override
     public CompletableFuture<Void> showHotspot(ServerHotspot h) {
+      return CompletableFutures.computeAsync(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> showTaintVulnerability(ShowAllLocationsCommand.Param params) {
       return CompletableFutures.computeAsync(null);
     }
 

--- a/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/JavaMediumTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/JavaMediumTests.java
@@ -137,7 +137,7 @@ class JavaMediumTests extends AbstractLanguageServerMediumTests {
     assertThat(diagnostics)
       .extracting(startLine(), startCharacter(), endLine(), endCharacter(), code(), Diagnostic::getSource, Diagnostic::getMessage, Diagnostic::getSeverity)
       .containsExactly(
-        tuple(7, 11, 7, 26, "java:S2259", "sonarlint", "\"NullPointerException\" will be thrown when invoking method \"doSomeThingWith()\". [+1 flow]", DiagnosticSeverity.Warning));
+        tuple(7, 11, 7, 26, "java:S2259", "sonarlint", "\"NullPointerException\" will be thrown when invoking method \"doSomeThingWith()\". [+5 locations]", DiagnosticSeverity.Warning));
   }
 
   @Test

--- a/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/LanguageServerMediumTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/LanguageServerMediumTests.java
@@ -484,7 +484,7 @@ class LanguageServerMediumTests extends AbstractLanguageServerMediumTests {
       .extracting(withoutTimestamp())
       .containsExactly(
         "[Info] Analyzing file '" + uri + "'...",
-        "[Info] Found 1 issue(s)"));
+        "[Info] Found 1 issue"));
   }
 
   @Test
@@ -502,7 +502,7 @@ class LanguageServerMediumTests extends AbstractLanguageServerMediumTests {
       .containsSubsequence(
         "[Debug] Queuing analysis of file '" + uri + "'",
         "[Info] Analyzing file '" + uri + "'...",
-        "[Info] Found 1 issue(s)"));
+        "[Info] Found 1 issue"));
   }
 
   @Test
@@ -522,7 +522,7 @@ class LanguageServerMediumTests extends AbstractLanguageServerMediumTests {
         "[Info] Index files",
         "[Info] 1 file indexed",
         "[Info] 1 source files to be analyzed",
-        "[Info] Found 1 issue(s)"));
+        "[Info] Found 1 issue"));
   }
 
   @Test
@@ -543,7 +543,7 @@ class LanguageServerMediumTests extends AbstractLanguageServerMediumTests {
         "[Debug] Language of file '" + uri + "' is set to 'JavaScript'",
         "[Info] 1 file indexed",
         "[Debug] Execute Sensor: JavaScript analysis",
-        "[Info] Found 1 issue(s)"));
+        "[Info] Found 1 issue"));
   }
 
   private Predicate<? super MessageParams> notFromContextualTSserver() {


### PR DESCRIPTION
This PR contains several changes:
- one new feature (code action to open a taint vulnerability in the browser)
- one missed feature (telemetry about taint vulnerabilities investigated locally)
- PM feedback from rounds of demos