### PR TITLE
Implement Stdio Channel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
       <artifactId>sonarlint-core</artifactId>
       <version>${sonarlint.core.version}</version>
     </dependency>
+       <dependency>
+       <groupId>info.picocli</groupId>
+       <artifactId>picocli</artifactId>
+       <version>4.6.3</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
@@ -29,6 +29,7 @@ import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -270,11 +271,18 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
       cancelToken.checkCanceled();
       this.traceLevel = parseTraceLevel(params.getTrace());
 
-      progressManager.setWorkDoneProgressSupportedByClient(ofNullable(params.getCapabilities().getWindow().getWorkDoneProgress()).orElse(false));
+      boolean workDoneSupportedByClient = ofNullable(params.getCapabilities())
+        .flatMap(capabilities -> ofNullable(capabilities.getWindow()))
+        .map(window -> window.getWorkDoneProgress())
+        .orElse(false);
+      progressManager.setWorkDoneProgressSupportedByClient(workDoneSupportedByClient);
 
       workspaceFoldersManager.initialize(params.getWorkspaceFolders());
 
       var options = Utils.parseToMap(params.getInitializationOptions());
+      if (options == null) {
+        options = Collections.emptyMap();
+      }
 
       var productKey = (String) options.get("productKey");
       // deprecated, will be ignored when productKey present
@@ -282,9 +290,10 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
 
       var productName = (String) options.get("productName");
       var productVersion = (String) options.get("productVersion");
-      this.appName = params.getClientInfo().getName();
+      var clientInfo = ofNullable(params.getClientInfo());
+      this.appName = clientInfo.map(ci -> ci.getName()).orElse("Unknown");
       var workspaceName = (String) options.get("workspaceName");
-      var clientVersion = params.getClientInfo().getVersion();
+      var clientVersion = clientInfo.map(ci -> ci.getVersion()).orElse("Unknown");
       var ideVersion = appName + " " + clientVersion;
       var firstSecretDetected = (boolean) options.getOrDefault("firstSecretDetected", false);
       httpClientProvider.initialize(productName, productVersion);

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
@@ -34,6 +34,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
@@ -174,6 +175,7 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
   private final TaintVulnerabilityRaisedNotification taintVulnerabilityRaisedNotification;
   private final BackendServiceFacade backendServiceFacade;
   private final Collection<Path> analyzers;
+  private final CountDownLatch shutdownLatch;
 
   SonarLintLanguageServer(InputStream inputStream, OutputStream outputStream, Collection<Path> analyzers) {
     this.threadPool = Executors.newCachedThreadPool(Utils.threadFactory("SonarLint LSP message processor", false));
@@ -249,12 +251,17 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
     this.workspaceFoldersManager.addListener(this.branchManager);
     this.workspaceFoldersManager.setBindingManager(bindingManager);
     this.taintIssuesUpdater = new TaintIssuesUpdater(bindingManager, taintVulnerabilitiesCache, workspaceFoldersManager, settingsManager, diagnosticPublisher);
+    this.shutdownLatch = new CountDownLatch(1);
     launcher.startListening();
   }
 
-  static void bySocket(int port, Collection<Path> analyzers) throws IOException {
+  static SonarLintLanguageServer bySocket(int port, Collection<Path> analyzers) throws IOException {
     var socket = new Socket("localhost", port);
-    new SonarLintLanguageServer(socket.getInputStream(), socket.getOutputStream(), analyzers);
+    return new SonarLintLanguageServer(socket.getInputStream(), socket.getOutputStream(), analyzers);
+  }
+
+  static SonarLintLanguageServer byStdio(List<Path> analyzers) {
+    return new SonarLintLanguageServer(System.in, System.out, analyzers);
   }
 
   @Override
@@ -369,7 +376,14 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
       backendServiceFacade::shutdown)
       // Do last
       .forEach(this::invokeQuietly);
+
+    shutdownLatch.countDown();
+
     return CompletableFuture.completedFuture(null);
+  }
+
+  public void waitForShutDown() throws InterruptedException {
+    shutdownLatch.await();
   }
 
   private void invokeQuietly(Runnable call) {

--- a/src/test/java/org/sonarsource/sonarlint/ls/ServerMainTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/ServerMainTests.java
@@ -47,6 +47,13 @@ class ServerMainTests {
   }
 
   @Test
+  void testRequiredArguments() {
+    cmd.execute();
+
+    assertThat(cmdOutput.toString()).startsWith("Use -stdio or -jsonRpcPort");
+  }
+
+  @Test
   void testInvalidPortArgument() {
     cmd.execute("not_a_number");
 

--- a/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/AbstractLanguageServerMediumTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/AbstractLanguageServerMediumTests.java
@@ -19,9 +19,9 @@
  */
 package org.sonarsource.sonarlint.ls.mediumtests;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.file.Files;
@@ -98,6 +98,7 @@ import org.sonarsource.sonarlint.ls.SonarLintExtendedLanguageClient;
 import org.sonarsource.sonarlint.ls.SonarLintExtendedLanguageServer;
 import org.sonarsource.sonarlint.ls.commands.ShowAllLocationsCommand;
 import org.sonarsource.sonarlint.ls.telemetry.SonarLintTelemetry;
+import picocli.CommandLine;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -133,7 +134,7 @@ public abstract class AbstractLanguageServerMediumTests {
 
     client = new FakeLanguageClient();
 
-    var executor = Executors.newSingleThreadExecutor();
+    var executor = Executors.newFixedThreadPool(2);
     var future = executor.submit(() -> {
       Socket socket = serverSocket.accept();
       Launcher<SonarLintExtendedLanguageServer> clientSideLauncher = new LSPLauncher.Builder<SonarLintExtendedLanguageServer>()
@@ -145,7 +146,6 @@ public abstract class AbstractLanguageServerMediumTests {
       clientSideLauncher.startListening();
       return clientSideLauncher.getRemoteProxy();
     });
-    executor.shutdown();
 
     var java = fullPathToJar("sonarjava");
     var js = fullPathToJar("sonarjs");
@@ -159,10 +159,16 @@ public abstract class AbstractLanguageServerMediumTests {
       var cfamily = fullPathToJar("cfamily");
       languageServerArgs = ArrayUtils.add(languageServerArgs, cfamily);
     }
-    var serverStdOut = new ByteArrayOutputStream();
-    var serverStdErr = new ByteArrayOutputStream();
+
     try {
-      new ServerMain(new PrintStream(serverStdOut), new PrintStream(serverStdErr)).startLanguageServer(languageServerArgs);
+      var cmd = new CommandLine(new ServerMain());
+      var cmdOutput = new StringWriter();
+      cmd.setErr(new PrintWriter(cmdOutput));
+      cmd.setOut(new PrintWriter(cmdOutput));
+
+      var clonedArgs = ArrayUtils.clone(languageServerArgs);
+      executor.submit(() -> cmd.execute(clonedArgs));
+      executor.shutdown();
     } catch (Exception e) {
       e.printStackTrace();
       future.get(1, TimeUnit.SECONDS);


### PR DESCRIPTION
This PR adds support for serving the language over stdio channel which is the default communication channel in tools such as Neovim. That use case has been also reported in the forum (see [here](https://community.sonarsource.com/t/running-sonarlint-language-server-from-shell/24440/14)).

The changes include but are still work in progress: 

- Use picocli to improve CLI parsing
- Start language server via stdio channeling
- Avoid NPE if client doesn't send initialize params

The language server works with Neovim (started with `java -jar /path/to/sonarlint-language-server/target/sonarlint-language-server-2.14.0-SNAPSHOT.jar -stdio -analyzers ~/Downloads/sonar/extension/analyzers/sonarjava.jar` and shown by `:LspInfo`, shown in the screencast) but there are no reports.

![output](https://user-images.githubusercontent.com/16558417/211385980-1526668d-e89f-4c78-9ade-b63b6bc04ff6.gif)

I have some lua stubs in my Neovim config in place but I'm not sure what is missing to get reports.

```lua
local M = {}

M.client_id = nil

function M.start_or_attach()
   local bufnr = vim.api.nvim_get_current_buf()

   local root_dir = vim.fs.dirname(vim.fs.find({'.git'}, { upward = true })[1])

   local config = {}
   config.name = 'sonarlint'
   config.cmd = { '/home/marc/Projekte/Open-Source/sonarlint-language-server/bin/sonarlint' }
   config.root_dir = root_dir
   config.handlers = {}
   config.handlers['sonarlint/isOpenInEditor'] = function(...)
      vim.pretty_print(...)
      return true
   end
   config.handlers['sonarlint/isIgnoredByScm'] = function(...)
      vim.pretty_print(...)
      return false
   end
   config.handlers['sonarlint/showSonarLintOutput'] = function(...)
      vim.pretty_print(...)
      return false
   end
   config.handlers['sonarlint/showSonarLintOutput'] = function(...)
      vim.pretty_print(...)
      return false
   end

   if not M.client_id then
      M.client_id = vim.lsp.start_client(config)
   end

   vim.lsp.buf_attach_client(bufnr, M.client_id)
end

return M
```

Any feedback is welcome.