### PR TITLE
SLVSCODE-406 Fix plugin key for embedded CFamily plugin

### DIFF
--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
@@ -621,7 +621,7 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
   public Map<String, Path> getEmbeddedPluginsToPath() {
     var plugins = new HashMap<String, Path>();
     analyzers.stream().filter(it -> it.toString().contains("cfamily")).findFirst()
-      .ifPresent(cfamilyPlugin -> plugins.put("cfamily", cfamilyPlugin));
+      .ifPresent(cfamilyPlugin -> plugins.put(Language.C.getPluginKey(), cfamilyPlugin));
     addPluginPathOrFail("html", Language.HTML, plugins);
     addPluginPathOrFail("js", Language.JS, plugins);
     addPluginPathOrFail("xml", Language.XML, plugins);


### PR DESCRIPTION
This change was a side effect of the refactoring from fe89708 and caused this exception:

```text
[Error - 17:14:08.242] Error starting connected SonarLint engine for 'SQDev9.9'
[Error - 17:14:08.243] java.lang.IllegalStateException: Duplicate plugin key 'cpp' from '/home/jean-baptistelievremont/.vscode/extensions/sonarsource.sonarlint-vscode-3.15.0+61639/analyzers/sonarcfamily.jar' and '/home/jean-baptistelievremont/.sonarlint/storage/5351446576392e39/plugins/sonar-cfamily-plugin-6.41.0.60884.jar'
	at org.sonarsource.sonarlint.core.plugin.commons.loading.SonarPluginRequirementsChecker.checkRequirements(SonarPluginRequirementsChecker.java:74)
	at org.sonarsource.sonarlint.core.plugin.commons.PluginsLoader.load(PluginsLoader.java:71)
	at org.sonarsource.sonarlint.core.ConnectedSonarLintEngineImpl.loadPlugins(ConnectedSonarLintEngineImpl.java:142)
	at org.sonarsource.sonarlint.core.ConnectedSonarLintEngineImpl.loadAnalysisContext(ConnectedSonarLintEngineImpl.java:116)
	at org.sonarsource.sonarlint.core.ConnectedSonarLintEngineImpl.start(ConnectedSonarLintEngineImpl.java:112)
	at org.sonarsource.sonarlint.core.ConnectedSonarLintEngineImpl.<init>(ConnectedSonarLintEngineImpl.java:102)
	at org.sonarsource.sonarlint.ls.EnginesFactory.newConnectedEngine(EnginesFactory.java:143)
	at org.sonarsource.sonarlint.ls.EnginesFactory.createConnectedEngine(EnginesFactory.java:136)
	at org.sonarsource.sonarlint.ls.connected.ProjectBindingManager.createConnectedEngine(ProjectBindingManager.java:255)
	at org.sonarsource.sonarlint.ls.connected.ProjectBindingManager.lambda$getOrCreateConnectedEngine$4(ProjectBindingManager.java:245)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708)
	at org.sonarsource.sonarlint.ls.connected.ProjectBindingManager.getOrCreateConnectedEngine(ProjectBindingManager.java:244)
	at org.sonarsource.sonarlint.ls.connected.ProjectBindingManager.computeProjectBinding(ProjectBindingManager.java:202)
	at org.sonarsource.sonarlint.ls.connected.ProjectBindingManager.lambda$getBinding$0(ProjectBindingManager.java:176)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708)
	at org.sonarsource.sonarlint.ls.connected.ProjectBindingManager.getBinding(ProjectBindingManager.java:169)
	at org.sonarsource.sonarlint.ls.connected.ProjectBindingManager.getBinding(ProjectBindingManager.java:154)
	at org.sonarsource.sonarlint.ls.folders.WorkspaceFoldersManager.lambda$addFolder$5(WorkspaceFoldersManager.java:126)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:577)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1589)
```