### PR TITLE
Stabilize tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ stages:
     stageDisplayName: Run UTs and trigger SonarQube and Mend analysis
     jobs:
     - job: test_windows
-      displayName: Run unit tests on Windows
+      displayName: Run unit tests on Windows with Java 17
       pool:
         vmImage: 'windows-latest'
       variables:
@@ -126,10 +126,10 @@ stages:
           testResultsFiles: '**/surefire-reports/TEST-*.xml'
           testRunTitle: 'UTs on Windows'
           javaHomeOption: 'JDKVersion'
-          jdkVersionOption: '1.11'
+          jdkVersionOption: '1.17'
           mavenOptions: $(MAVEN_OPTS)
     - job: test_linux
-      displayName: 'Run unit tests on Linux'
+      displayName: 'Run unit tests on Linux with Java 11'
       pool:
         vmImage: 'ubuntu-latest'
       variables:

--- a/pom.xml
+++ b/pom.xml
@@ -28,12 +28,12 @@
     <!-- Version used by Xodus -->
     <kotlin.version>1.6.10</kotlin.version>
     <!-- analyzers used for tests -->
-    <sonar.java.version>7.7.0.28547</sonar.java.version>
-    <sonar.javascript.version>9.11.0.20161</sonar.javascript.version>
-    <sonar.php.version>3.5.0.5655</sonar.php.version>
+    <sonar.java.version>7.17.0.31219</sonar.java.version>
+    <sonar.javascript.version>10.0.1.20755</sonar.javascript.version>
+    <sonar.php.version>3.28.0.9490</sonar.php.version>
     <sonar.python.version>4.1.0.11182</sonar.python.version>
-    <sonar.html.version>3.2.0.2082</sonar.html.version>
-    <sonar.xml.version>2.5.0.3376</sonar.xml.version>
+    <sonar.html.version>3.7.1.3306</sonar.html.version>
+    <sonar.xml.version>2.7.0.3820</sonar.xml.version>
     <sonar.text.version>2.0.1.611</sonar.text.version>
     <gitRepositoryName>sonarlint-language-server</gitRepositoryName>
     <!-- Release: enable publication to Bintray -->

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintExtendedLanguageClient.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintExtendedLanguageClient.java
@@ -436,4 +436,7 @@ public interface SonarLintExtendedLanguageClient extends LanguageClient {
 
   @JsonNotification("sonarlint/publishSecurityHotspots")
   void publishSecurityHotspots(PublishDiagnosticsParams publishDiagnosticsParams);
+
+  @JsonNotification("sonarlint/readyForTests")
+  void readyForTests();
 }

--- a/src/main/java/org/sonarsource/sonarlint/ls/connected/notifications/ServerNotifications.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/connected/notifications/ServerNotifications.java
@@ -120,6 +120,7 @@ public class ServerNotifications implements WorkspaceSettingsChangeListener, Wor
         // Connection is unknown, or has notifications disabled - do nothing
         return;
       }
+      client.readyForTests();
       logOutput.debug(String.format("Enabling notifications for project '%s' on connection '%s'", projectKey, connectionId));
       var newConfiguration = newNotificationConfiguration(connections.get(connectionId), projectKey);
       serverNotificationsRegistry.register(newConfiguration);

--- a/src/test/java/org/sonarsource/sonarlint/ls/connected/notifications/ServerNotificationsTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/connected/notifications/ServerNotificationsTests.java
@@ -102,6 +102,7 @@ class ServerNotificationsTests {
 
     verify(output, times(1)).debug("Enabling notifications for project 'projectKey' on connection 'connectionId'");
     verify(workspaceFoldersManager).getAll();
+    verify(client).readyForTests();
   }
 
   @Test
@@ -127,6 +128,7 @@ class ServerNotificationsTests {
     verify(output, times(1)).debug("Enabling notifications for project 'projectKey1' on connection 'connectionId'");
     verify(output, times(1)).debug("Enabling notifications for project 'projectKey2' on connection 'connectionId'");
     verify(workspaceFoldersManager).getAll();
+    verify(client, times(2)).readyForTests();
   }
 
   @Test
@@ -150,6 +152,7 @@ class ServerNotificationsTests {
 
     verify(output, times(1)).debug("De-registering notifications for project 'projectKey' on connection 'connectionId'");
     verify(workspaceFoldersManager).getAll();
+    verify(client).readyForTests();
   }
 
   @Test
@@ -176,6 +179,7 @@ class ServerNotificationsTests {
 
     verify(output, times(1)).debug("Enabling notifications for project 'projectKey' on connection 'connectionId'");
     verify(workspaceFoldersManager, times(2)).getAll();
+    verify(client).readyForTests();
   }
 
   @Test
@@ -224,6 +228,7 @@ class ServerNotificationsTests {
     verify(output, times(1)).debug("De-registering notifications for project 'projectKey' on connection 'connectionId'");
     verify(output, times(2)).debug("Enabling notifications for project 'projectKey' on connection 'connectionId'");
     verify(workspaceFoldersManager, times(2)).getAll();
+    verify(client, times(2)).readyForTests();
   }
 
   @Test

--- a/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/AbstractLanguageServerMediumTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/AbstractLanguageServerMediumTests.java
@@ -155,7 +155,7 @@ public abstract class AbstractLanguageServerMediumTests {
     var html = fullPathToJar("sonarhtml");
     var xml = fullPathToJar("sonarxml");
     var text = fullPathToJar("sonartext");
-    String[] languageServerArgs = new String[] {"" + port, "-analyzers", java, js, php, py, html, xml, text};
+    String[] languageServerArgs = new String[]{"" + port, "-analyzers", java, js, php, py, html, xml, text};
     if (COMMERCIAL_ENABLED) {
       var cfamily = fullPathToJar("cfamily");
       languageServerArgs = ArrayUtils.add(languageServerArgs, cfamily);
@@ -235,9 +235,14 @@ public abstract class AbstractLanguageServerMediumTests {
     setUpFolderSettings(client.folderSettings);
 
     notifyConfigurationChangeOnClient();
+    verifyConfigurationChangeOnClient();
   }
 
   protected void setUpFolderSettings(Map<String, Map<String, Object>> folderSettings) {
+    // do nothing by default
+  }
+
+  protected void verifyConfigurationChangeOnClient() {
     // do nothing by default
   }
 
@@ -292,6 +297,7 @@ public abstract class AbstractLanguageServerMediumTests {
     CountDownLatch settingsLatch = new CountDownLatch(0);
     CountDownLatch showRuleDescriptionLatch = new CountDownLatch(0);
     CountDownLatch suggestBindingLatch = new CountDownLatch(0);
+    CountDownLatch readyForTestsLatch = new CountDownLatch(0);
     SuggestBindingParams suggestedBindings;
     ShowRuleDescriptionParams ruleDesc;
     boolean isIgnoredByScm = false;
@@ -311,6 +317,7 @@ public abstract class AbstractLanguageServerMediumTests {
       settingsLatch = new CountDownLatch(0);
       showRuleDescriptionLatch = new CountDownLatch(0);
       suggestBindingLatch = new CountDownLatch(0);
+      readyForTestsLatch = new CountDownLatch(0);
       needCompilationDatabaseCalls.set(0);
       isOpenInEditor = true;
     }
@@ -378,6 +385,11 @@ public abstract class AbstractLanguageServerMediumTests {
         }
         return result;
       });
+    }
+
+    @Override
+    public void readyForTests() {
+      readyForTestsLatch.countDown();
     }
 
     @Override

--- a/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/AbstractLanguageServerMediumTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/AbstractLanguageServerMediumTests.java
@@ -182,7 +182,7 @@ public abstract class AbstractLanguageServerMediumTests {
     lsProxy = future.get();
   }
 
-  private static String fullPathToJar(String jarName) {
+  protected static String fullPathToJar(String jarName) {
     return Paths.get("target/plugins").resolve(jarName + ".jar").toAbsolutePath().toString();
   }
 

--- a/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/LanguageServerMediumTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/LanguageServerMediumTests.java
@@ -212,7 +212,11 @@ class LanguageServerMediumTests extends AbstractLanguageServerMediumTests {
 
     awaitUntilAsserted(() -> assertThat(client.getDiagnostics(uri))
       .extracting(startLine(), startCharacter(), endLine(), endCharacter(), code(), Diagnostic::getSource, Diagnostic::getMessage, Diagnostic::getSeverity)
-      .containsExactly(tuple(2, 2, 2, 6, "php:S2041", "sonarlint", "Remove the parentheses from this \"echo\" call.", DiagnosticSeverity.Warning)));
+      .containsExactlyInAnyOrder(
+        tuple(0, 0, 0, 0, "php:S113", "sonarlint", "Add a new line at the end of this file.", DiagnosticSeverity.Information),
+        tuple(1, 15, 1, 16, "php:S1808", "sonarlint", "Move this open curly brace to the beginning of the next line.", DiagnosticSeverity.Information),
+        tuple(2, 2, 2, 6, "php:S2041", "sonarlint", "Remove the parentheses from this \"echo\" call.", DiagnosticSeverity.Warning),
+        tuple(4, 0, 4, 2, "php:S1780", "sonarlint", "Remove this closing tag \"?>\".", DiagnosticSeverity.Information)));
   }
 
   @Test


### PR DESCRIPTION
**Stabilize tests**
- Replace JS analyzer with Python analyzer where appropriate.
- Add 'readyForTests' notification to notify tests about readiness.

**Stabilize/Improve builds**
- Run builds with different Java versions. Linux is run with v11, and Windows with v17.
- Update analyzers to versions used by SonarLint in production or newer.