### PR TITLE
Fix @TempDir directory cannot be deleted 

### DIFF
--- a/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/ConnectedModeMediumTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/ConnectedModeMediumTests.java
@@ -21,6 +21,7 @@ package org.sonarsource.sonarlint.ls.mediumtests;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -33,11 +34,11 @@ import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.ExecuteCommandParams;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.api.io.TempDir;
 import org.sonar.scanner.protocol.Constants.Severity;
 import org.sonar.scanner.protocol.input.ScannerInput;
 import org.sonarsource.sonarlint.core.commons.RuleType;
@@ -78,11 +79,11 @@ class ConnectedModeMediumTests extends AbstractLanguageServerMediumTests {
   private static final String PROJECT_KEY2 = "project:key2";
   private static final String PROJECT_NAME2 = "Project Two";
   private static final long CURRENT_TIME = System.currentTimeMillis();
-  @TempDir
-  public static Path folder1BaseDir;
+  private static Path folder1BaseDir;
 
   @BeforeAll
   public static void initialize() throws Exception {
+    folder1BaseDir = Files.createTempDirectory(null);
     initialize(Map.of(
       "telemetryStorage", "not/exists",
       "productName", "SLCORE tests",
@@ -164,6 +165,11 @@ class ConnectedModeMediumTests extends AbstractLanguageServerMediumTests {
     } catch (InterruptedException e) {
       fail(e);
     }
+  }
+
+  @AfterAll
+  public static void cleanUp() {
+    folder1BaseDir.toFile().delete();
   }
 
   @Test

--- a/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/ConnectedModeMediumTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/ConnectedModeMediumTests.java
@@ -29,6 +29,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import mockwebserver3.MockResponse;
 import okio.Buffer;
+import org.apache.commons.io.FileUtils;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.ExecuteCommandParams;
@@ -169,7 +170,7 @@ class ConnectedModeMediumTests extends AbstractLanguageServerMediumTests {
 
   @AfterAll
   public static void cleanUp() {
-    folder1BaseDir.toFile().delete();
+    FileUtils.deleteQuietly(folder1BaseDir.toFile());
   }
 
   @Test

--- a/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/ConnectedModeMediumTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/ConnectedModeMediumTests.java
@@ -21,7 +21,6 @@ package org.sonarsource.sonarlint.ls.mediumtests;
 
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -84,7 +83,7 @@ class ConnectedModeMediumTests extends AbstractLanguageServerMediumTests {
 
   @BeforeAll
   public static void initialize() throws Exception {
-    folder1BaseDir = Files.createTempDirectory(null);
+    folder1BaseDir = makeStaticTempDir();
     initialize(Map.of(
       "telemetryStorage", "not/exists",
       "productName", "SLCORE tests",

--- a/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/JavaMediumTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/JavaMediumTests.java
@@ -43,17 +43,17 @@ import static org.assertj.core.groups.Tuple.tuple;
 
 class JavaMediumTests extends AbstractLanguageServerMediumTests {
 
-  @TempDir
-  public static Path module1Path;
+  private static Path module1Path;
 
-  @TempDir
-  public static Path module2Path;
+  private static Path module2Path;
 
   private static String MODULE_1_ROOT_URI;
   private static String MODULE_2_ROOT_URI;
 
   @BeforeAll
   static void initialize() throws Exception {
+    module1Path = makeStaticTempDir();
+    module2Path = makeStaticTempDir();
     MODULE_1_ROOT_URI = module1Path.toUri().toString();
     MODULE_2_ROOT_URI = module2Path.toUri().toString();
 

--- a/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/LanguageServerWithFoldersMediumTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/LanguageServerWithFoldersMediumTests.java
@@ -32,7 +32,6 @@ import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.WorkspaceFoldersChangeEvent;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
@@ -41,14 +40,14 @@ class LanguageServerWithFoldersMediumTests extends AbstractLanguageServerMediumT
 
   private static final String PYTHON_S1481 = "python:S1481";
 
-  @TempDir
-  public static Path folder1BaseDir;
+  private static Path folder1BaseDir;
 
-  @TempDir
-  public static Path folder2BaseDir;
+  private static Path folder2BaseDir;
 
   @BeforeAll
   public static void initialize() throws Exception {
+    folder1BaseDir = makeStaticTempDir();
+    folder2BaseDir = makeStaticTempDir();
     initialize(Map.of(
       "telemetryStorage", "not/exists",
       "productName", "SLCORE tests",


### PR DESCRIPTION
Fix `@TempDir` directory cannot be deleted ([ConnectedModeMediumTests IO Failed to delete temp directory](https://dev.azure.com/sonarsource/DotNetTeam%20Project/_build/results?buildId=64605&view=logs&j=81cabcdf-75d9-5672-240e-9040d2927080&s=3df7d716-4c9c-5c26-9f45-11f62216640d&t=1b57360e-bdec-515f-6474-56e699defbf8&l=2351)) by creating and deleting temp dir manually. 
Currently done only for ConnectedModeMediumTests as that's where the issue is observed.