### PR TITLE
SLLS-152    Add method to pass IssueStatus and Comment to SLCORE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <jdk.min.version>11</jdk.min.version>
-    <sonarlint.core.version>8.19.0.71330</sonarlint.core.version>
+    <sonarlint.core.version>8.19.0.71458</sonarlint.core.version>
     <!-- Version used by Xodus -->
     <kotlin.version>1.6.10</kotlin.version>
     <!-- analyzers used for tests -->

--- a/src/main/java/org/sonarsource/sonarlint/ls/DiagnosticPublisher.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/DiagnosticPublisher.java
@@ -180,9 +180,10 @@ public class DiagnosticPublisher {
       .map(DiagnosticPublisher::convert);
     var taintDiagnostics = taintVulnerabilitiesCache.getAsDiagnostics(newUri);
 
-    p.setDiagnostics(Stream.concat(localDiagnostics, taintDiagnostics)
+    var diagnosticList = Stream.concat(localDiagnostics, taintDiagnostics)
       .sorted(DiagnosticPublisher.byLineNumber())
-      .collect(toList()));
+      .collect(toList());
+    p.setDiagnostics(diagnosticList);
     p.setUri(newUri.toString());
 
     return p;

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintExtendedLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintExtendedLanguageServer.java
@@ -35,6 +35,8 @@ import org.eclipse.xtext.xbase.lib.Pure;
 import org.sonarsource.sonarlint.core.clientapi.backend.analysis.GetSupportedFilePatternsResponse;
 import org.sonarsource.sonarlint.core.clientapi.backend.authentication.HelpGenerateUserTokenResponse;
 import org.sonarsource.sonarlint.core.clientapi.backend.binding.GetBindingSuggestionParams;
+import org.sonarsource.sonarlint.core.clientapi.backend.issue.AddIssueCommentParams;
+import org.sonarsource.sonarlint.core.clientapi.backend.issue.IssueStatus;
 import org.sonarsource.sonarlint.core.clientapi.client.binding.GetBindingSuggestionsResponse;
 
 public interface SonarLintExtendedLanguageServer extends LanguageServer {
@@ -375,6 +377,48 @@ public interface SonarLintExtendedLanguageServer extends LanguageServer {
 
   @JsonRequest("sonarlint/getBindingSuggestion")
   CompletableFuture<GetBindingSuggestionsResponse> getBindingSuggestion(GetBindingSuggestionParams params);
+
+  class ChangeIssueStatusParams {
+    private final String configurationScopeId;
+    private final String issueKey;
+    private final IssueStatus newStatus;
+    private final String fileUri;
+    private final boolean isTaintIssue;
+
+    public ChangeIssueStatusParams(String configurationScopeId, String issueKey, IssueStatus newStatus, String fileUri, boolean isTaintIssue) {
+      this.configurationScopeId = configurationScopeId;
+      this.issueKey = issueKey;
+      this.newStatus = newStatus;
+      this.fileUri = fileUri;
+      this.isTaintIssue = isTaintIssue;
+    }
+
+    public String getConfigurationScopeId() {
+      return configurationScopeId;
+    }
+
+    public String getIssueKey() {
+      return issueKey;
+    }
+
+    public IssueStatus getNewStatus() {
+      return newStatus;
+    }
+
+    public String getFileUri() {
+      return fileUri;
+    }
+
+    public boolean isTaintIssue() {
+      return isTaintIssue;
+    }
+  }
+
+  @JsonNotification("sonarlint/changeIssueStatus")
+  CompletableFuture<Void> changeIssueStatus(ChangeIssueStatusParams params);
+
+  @JsonNotification("sonarlint/addIssueComment")
+  CompletableFuture<Void> addIssueComment(AddIssueCommentParams params);
 
   class CheckLocalDetectionSupportedResponse {
     boolean isSupported;

--- a/src/main/java/org/sonarsource/sonarlint/ls/backend/BackendService.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/backend/BackendService.java
@@ -46,6 +46,8 @@ import org.sonarsource.sonarlint.core.clientapi.backend.connection.config.SonarQ
 import org.sonarsource.sonarlint.core.clientapi.backend.hotspot.CheckLocalDetectionSupportedParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.hotspot.CheckLocalDetectionSupportedResponse;
 import org.sonarsource.sonarlint.core.clientapi.backend.hotspot.OpenHotspotInBrowserParams;
+import org.sonarsource.sonarlint.core.clientapi.backend.issue.AddIssueCommentParams;
+import org.sonarsource.sonarlint.core.clientapi.backend.issue.ChangeIssueStatusParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.rules.GetEffectiveRuleDetailsParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.rules.GetEffectiveRuleDetailsResponse;
 import org.sonarsource.sonarlint.core.clientapi.backend.rules.GetStandaloneRuleDescriptionParams;
@@ -166,6 +168,14 @@ public class BackendService {
 
   public CompletableFuture<GetBindingSuggestionsResponse> getBindingSuggestion(GetBindingSuggestionParams params) {
     return initializedBackend().getBindingService().getBindingSuggestions(params);
+  }
+
+  public CompletableFuture<Void> changeIssueStatus(ChangeIssueStatusParams params){
+    return initializedBackend().getIssueService().changeStatus(params);
+  }
+
+  public CompletableFuture<Void> addIssueComment(AddIssueCommentParams params){
+    return initializedBackend().getIssueService().addComment(params);
   }
 
   public void notifyBackendOnBranchChanged(String folderUri, String newBranchName) {

--- a/src/main/java/org/sonarsource/sonarlint/ls/connected/TaintVulnerabilitiesCache.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/connected/TaintVulnerabilitiesCache.java
@@ -107,6 +107,15 @@ public class TaintVulnerabilitiesCache {
     taintVulnerabilitiesPerFile.put(fileUri, taintIssues);
   }
 
+  public void removeTaintIssue(String fileUriStr, String key) {
+    var fileUri = URI.create(fileUriStr);
+    var issues = taintVulnerabilitiesPerFile.get(fileUri);
+    if (issues != null) {
+      var issueToRemove = issues.stream().filter(taintIssue -> taintIssue.getKey().equals(key)).findFirst();
+      issueToRemove.ifPresent(issues::remove);
+    }
+  }
+
   public Set<URI> getAllFilesWithTaintIssues(){
     return taintVulnerabilitiesPerFile.keySet();
   }

--- a/src/main/java/org/sonarsource/sonarlint/ls/http/ApacheHttpClient.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/http/ApacheHttpClient.java
@@ -183,6 +183,13 @@ public class ApacheHttpClient implements HttpClient {
   }
 
   @Override
+  public CompletableFuture<Response> postAsync(String url, String contentType, String body) {
+    var httpPost = SimpleRequestBuilder.post(url);
+    httpPost.setBody(body, ContentType.parse(contentType));
+    return executeAsync(httpPost);
+  }
+
+  @Override
   public Response delete(String url, String contentType, String body) {
     var httpDelete = SimpleRequestBuilder.delete(url);
     httpDelete.setBody(body, ContentType.parse(contentType));

--- a/src/test/java/org/sonarsource/sonarlint/ls/connected/TaintVulnerabilitiesCacheTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/connected/TaintVulnerabilitiesCacheTests.java
@@ -20,6 +20,8 @@
 package org.sonarsource.sonarlint.ls.connected;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
@@ -156,6 +158,24 @@ class TaintVulnerabilitiesCacheTests {
 
     assertThat(underTest.getTaintVulnerabilityByKey(issueKey)).hasValue(issue);
     assertThat(underTest.getTaintVulnerabilityByKey("otherKey")).isEmpty();
+  }
+
+  @Test
+  void testRemoveTaintIssue() throws Exception {
+    var uri = new URI("/");
+    var issue = mock(TaintIssue.class);
+    var issueKey = "key";
+    when(issue.getKey()).thenReturn(issueKey);
+    when(issue.getRuleKey()).thenReturn(SAMPLE_SECURITY_RULE_KEY);
+    when(issue.isResolved()).thenReturn(false);
+
+    underTest.getTaintVulnerabilitiesPerFile().put(uri,  new ArrayList<>(Arrays.asList(issue)));
+    assertThat(underTest.getTaintVulnerabilityByKey(issueKey)).hasValue(issue);
+
+    underTest.removeTaintIssue(uri.toString(), issueKey);
+    assertThat(underTest.getTaintVulnerabilityByKey(issueKey)).isEmpty();
+
+
   }
 
 }

--- a/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/AbstractLanguageServerMediumTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/AbstractLanguageServerMediumTests.java
@@ -245,12 +245,6 @@ public abstract class AbstractLanguageServerMediumTests {
     verifyConfigurationChangeOnClient();
   }
 
-  @AfterEach
-  void cleanupTempDirs() throws Exception {
-    instanceTempDirs.forEach(tempDirPath -> FileUtils.deleteQuietly(tempDirPath.toFile()));
-    instanceTempDirs.clear();
-  }
-
   protected void setUpFolderSettings(Map<String, Map<String, Object>> folderSettings) {
     // do nothing by default
   }
@@ -273,6 +267,8 @@ public abstract class AbstractLanguageServerMediumTests {
     event.setRemoved(foldersToRemove.stream().map(WorkspaceFolder::new).collect(Collectors.toList()));
     changeWorkspaceFoldersParams.setEvent(event);
     lsProxy.getWorkspaceService().didChangeWorkspaceFolders(changeWorkspaceFoldersParams);
+    instanceTempDirs.forEach(tempDirPath -> FileUtils.deleteQuietly(tempDirPath.toFile()));
+    instanceTempDirs.clear();
   }
 
   protected static void assertLogContains(String msg) {
@@ -324,6 +320,7 @@ public abstract class AbstractLanguageServerMediumTests {
       diagnostics.clear();
       hotspots.clear();
       logs.clear();
+      shownMessages.clear();
       globalSettings = new HashMap<>();
       setDisableTelemetry(globalSettings, true);
       folderSettings.clear();

--- a/src/test/java/testutils/MockWebServerExtension.java
+++ b/src/test/java/testutils/MockWebServerExtension.java
@@ -65,6 +65,10 @@ public class MockWebServerExtension implements BeforeEachCallback, AfterEachCall
 
   @Override
   public void afterEach(ExtensionContext context) throws Exception {
+    stopServer();
+  }
+
+  public void stopServer() throws IOException {
     server.shutdown();
   }
 


### PR DESCRIPTION
- Add Code Action to an issue (applicable for both taint issues and regular issues)
- When the client requests muting an issue, forward the data to an appropriate handler from SLCORE