### PR TITLE
SLLS-160 update org.eclipse.jgit to 6.5.0.202303070854-r

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
-      <version>6.4.0.202211300538-r</version>
+      <version>6.5.0.202303070854-r</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/test/java/org/sonarsource/sonarlint/ls/folders/WorkspaceFolderBranchManagerTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/folders/WorkspaceFolderBranchManagerTests.java
@@ -39,12 +39,9 @@ import org.sonarsource.sonarlint.ls.backend.BackendServiceFacade;
 import org.sonarsource.sonarlint.ls.connected.ProjectBindingManager;
 import org.sonarsource.sonarlint.ls.connected.ProjectBindingWrapper;
 import org.sonarsource.sonarlint.ls.settings.ServerConnectionSettings;
-import org.sonarsource.sonarlint.ls.util.Utils;
 import testutils.ImmediateExecutorService;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
update org.eclipse.jgit 6.4.0.202211300538-r --> 6.5.0.202303070854-r

Looks like we use jgit only in tests so updating it should be safe enough change 