### PR TITLE
BUILD-3062 fix Mend product name

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -115,6 +115,7 @@ mend_scan_task:
     memory: 2G
   env:
     WS_APIKEY: VAULT[development/kv/data/mend data.apikey]
+    WS_PRODUCTNAME: SonarLint/LanguageServer
   maven_cache:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository
   mend_script:


### PR DESCRIPTION
Circumvent BUILD-3169 (ws_scan.sh overrides product names from wss-unified-agent.config
