### PR TITLE
SLLS-169 Improve name for 'Mark as Resolved' action

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <jdk.min.version>11</jdk.min.version>
-    <sonarlint.core.version>9.0.0.74108</sonarlint.core.version>
+    <sonarlint.core.version>9.0.0.74282</sonarlint.core.version>
     <!-- Version used by Xodus -->
     <kotlin.version>1.6.10</kotlin.version>
     <!-- analyzers used for tests -->

--- a/src/main/java/org/sonarsource/sonarlint/ls/CommandManager.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/CommandManager.java
@@ -195,7 +195,7 @@ public class CommandManager {
   private CodeAction createResolveIssueCodeAction(Diagnostic diagnostic, String ruleKey, String serverIssueKey,  URI fileUri, boolean isTaintIssue) {
     var workspace = workspaceFoldersManager.findFolderForFile(fileUri).orElseThrow(() -> new IllegalStateException("No workspace found"));
     var workspaceUri = workspace.getUri();
-    var resolveIssueAction = new CodeAction(String.format(SONARLINT_ACTION_PREFIX + "Resolve this issue violating rule '%s'", ruleKey));
+    var resolveIssueAction = new CodeAction(String.format(SONARLINT_ACTION_PREFIX + "Resolve issue violating rule '%s' as...", ruleKey));
     resolveIssueAction.setKind(CodeActionKind.QuickFix);
     resolveIssueAction.setDiagnostics(List.of(diagnostic));
     resolveIssueAction.setCommand(new Command("Resolve this issue", RESOLVE_ISSUE, List.of(workspaceUri.toString(), serverIssueKey, fileUri, isTaintIssue)));

--- a/src/main/java/org/sonarsource/sonarlint/ls/backend/BackendService.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/backend/BackendService.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.sonarsource.sonarlint.core.clientapi.SonarLintBackend;
-import org.sonarsource.sonarlint.core.clientapi.backend.InitializeParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.analysis.GetSupportedFilePatternsParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.analysis.GetSupportedFilePatternsResponse;
 import org.sonarsource.sonarlint.core.clientapi.backend.binding.GetBindingSuggestionParams;
@@ -51,6 +50,7 @@ import org.sonarsource.sonarlint.core.clientapi.backend.hotspot.CheckLocalDetect
 import org.sonarsource.sonarlint.core.clientapi.backend.hotspot.CheckStatusChangePermittedParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.hotspot.CheckStatusChangePermittedResponse;
 import org.sonarsource.sonarlint.core.clientapi.backend.hotspot.OpenHotspotInBrowserParams;
+import org.sonarsource.sonarlint.core.clientapi.backend.initialize.InitializeParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.issue.AddIssueCommentParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.issue.ChangeIssueStatusParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.rules.GetEffectiveRuleDetailsParams;

--- a/src/main/java/org/sonarsource/sonarlint/ls/backend/BackendServiceFacade.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/backend/BackendServiceFacade.java
@@ -29,8 +29,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.sonarsource.sonarlint.core.clientapi.SonarLintBackend;
-import org.sonarsource.sonarlint.core.clientapi.backend.HostInfoDto;
-import org.sonarsource.sonarlint.core.clientapi.backend.InitializeParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.config.binding.BindingConfigurationDto;
 import org.sonarsource.sonarlint.core.clientapi.backend.config.scope.ConfigurationScopeDto;
 import org.sonarsource.sonarlint.core.clientapi.backend.config.scope.DidAddConfigurationScopesParams;
@@ -40,6 +38,9 @@ import org.sonarsource.sonarlint.core.clientapi.backend.connection.validate.Vali
 import org.sonarsource.sonarlint.core.clientapi.backend.connection.validate.ValidateConnectionResponse;
 import org.sonarsource.sonarlint.core.clientapi.backend.hotspot.CheckLocalDetectionSupportedParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.hotspot.CheckLocalDetectionSupportedResponse;
+import org.sonarsource.sonarlint.core.clientapi.backend.initialize.ClientInfoDto;
+import org.sonarsource.sonarlint.core.clientapi.backend.initialize.FeatureFlagsDto;
+import org.sonarsource.sonarlint.core.clientapi.backend.initialize.InitializeParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.rules.GetEffectiveRuleDetailsParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.rules.GetEffectiveRuleDetailsResponse;
 import org.sonarsource.sonarlint.core.clientapi.backend.rules.GetStandaloneRuleDescriptionParams;
@@ -106,24 +107,18 @@ public class BackendServiceFacade {
 
   private static InitializeParams toInitParams(BackendInitParams initParams) {
     return new InitializeParams(
-      new HostInfoDto("Visual Studio Code"),
-      initParams.getTelemetryProductKey(),
+      new ClientInfoDto("Visual Studio Code", initParams.getTelemetryProductKey(), initParams.getUserAgent()),
+      new FeatureFlagsDto(true, true, true, true, initParams.isEnableSecurityHotspots()),
       initParams.getStorageRoot(),
       null,
       initParams.getEmbeddedPluginPaths(),
       initParams.getConnectedModeEmbeddedPluginPathsByKey(),
       initParams.getEnabledLanguagesInStandaloneMode(),
       initParams.getExtraEnabledLanguagesInConnectedMode(),
-      initParams.isEnableSecurityHotspots(),
       initParams.getSonarQubeConnections(),
       initParams.getSonarCloudConnections(),
       initParams.getSonarlintUserHome(),
-      true,
-      initParams.getStandaloneRuleConfigByKey(),
-      true,
-      true,
-      true,
-      initParams.getUserAgent()
+      initParams.getStandaloneRuleConfigByKey()
     );
   }
 

--- a/src/main/java/org/sonarsource/sonarlint/ls/clientapi/SonarLintVSCodeClient.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/clientapi/SonarLintVSCodeClient.java
@@ -34,6 +34,7 @@ import org.sonarsource.sonarlint.core.clientapi.client.fs.FindFileByNamesInScope
 import org.sonarsource.sonarlint.core.clientapi.client.fs.FindFileByNamesInScopeResponse;
 import org.sonarsource.sonarlint.core.clientapi.client.http.CheckServerTrustedParams;
 import org.sonarsource.sonarlint.core.clientapi.client.http.CheckServerTrustedResponse;
+import org.sonarsource.sonarlint.core.clientapi.client.info.GetClientInfoResponse;
 import org.sonarsource.sonarlint.core.clientapi.client.progress.ReportProgressParams;
 import org.sonarsource.sonarlint.core.clientapi.client.progress.StartProgressParams;
 import org.sonarsource.sonarlint.core.clientapi.client.smartnotification.ShowSmartNotificationParams;
@@ -94,7 +95,7 @@ public class SonarLintVSCodeClient implements SonarLintClient {
   }
 
   @Override
-  public CompletableFuture<org.sonarsource.sonarlint.core.clientapi.client.host.GetHostInfoResponse> getHostInfo() {
+  public CompletableFuture<GetClientInfoResponse> getClientInfo() {
     return CompletableFuture.completedFuture(server.getHostInfo());
   }
 

--- a/src/main/java/org/sonarsource/sonarlint/ls/connected/api/RequestsHandlerServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/connected/api/RequestsHandlerServer.java
@@ -25,7 +25,7 @@ import org.eclipse.lsp4j.MessageActionItem;
 import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.ShowMessageRequestParams;
 import org.sonarsource.sonarlint.core.clientapi.client.binding.AssistBindingParams;
-import org.sonarsource.sonarlint.core.clientapi.client.host.GetHostInfoResponse;
+import org.sonarsource.sonarlint.core.clientapi.client.info.GetClientInfoResponse;
 import org.sonarsource.sonarlint.ls.SonarLintExtendedLanguageClient;
 
 public class RequestsHandlerServer {
@@ -42,8 +42,8 @@ public class RequestsHandlerServer {
     this.workspaceName = workspaceName == null ? "(no open folder)" : workspaceName;
   }
 
-  public GetHostInfoResponse getHostInfo() {
-    return new GetHostInfoResponse(this.clientVersion + " - " + this.workspaceName);
+  public GetClientInfoResponse getHostInfo() {
+    return new GetClientInfoResponse(this.clientVersion + " - " + this.workspaceName);
   }
 
   public void showHotspotHandleUnknownServer(String url) {

--- a/src/test/java/org/sonarsource/sonarlint/ls/CommandManagerTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/CommandManagerTests.java
@@ -300,7 +300,7 @@ class CommandManagerTests {
       "SonarLint: Open description of rule 'ruleKey'",
       "SonarLint: Show all locations for taint vulnerability 'ruleKey'",
       "SonarLint: Open taint vulnerability 'ruleKey' on 'connectionId'",
-      "SonarLint: Resolve this issue violating rule 'ruleKey'");
+      "SonarLint: Resolve issue violating rule 'ruleKey' as...");
 
     assertThat(codeActions.get(0).getRight().getCommand().getArguments()).containsOnly(
       "ruleKey",
@@ -626,7 +626,7 @@ class CommandManagerTests {
 
     assertThat(codeActions).extracting(c -> c.getRight().getTitle())
       .containsExactly(
-        "SonarLint: Resolve this issue violating rule 'XYZ'",
+        "SonarLint: Resolve issue violating rule 'XYZ' as...",
         "SonarLint: Open description of rule 'XYZ'");
   }
 

--- a/src/test/java/org/sonarsource/sonarlint/ls/clientapi/SonarLintVSCodeClientTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/clientapi/SonarLintVSCodeClientTests.java
@@ -35,11 +35,11 @@ import org.sonarsource.sonarlint.core.clientapi.client.binding.AssistBindingPara
 import org.sonarsource.sonarlint.core.clientapi.client.binding.SuggestBindingParams;
 import org.sonarsource.sonarlint.core.clientapi.client.connection.AssistCreatingConnectionParams;
 import org.sonarsource.sonarlint.core.clientapi.client.fs.FindFileByNamesInScopeParams;
-import org.sonarsource.sonarlint.core.clientapi.client.host.GetHostInfoResponse;
 import org.sonarsource.sonarlint.core.clientapi.client.hotspot.HotspotDetailsDto;
 import org.sonarsource.sonarlint.core.clientapi.client.hotspot.ShowHotspotParams;
 import org.sonarsource.sonarlint.core.clientapi.client.http.CheckServerTrustedParams;
 import org.sonarsource.sonarlint.core.clientapi.client.http.X509CertificateDto;
+import org.sonarsource.sonarlint.core.clientapi.client.info.GetClientInfoResponse;
 import org.sonarsource.sonarlint.core.clientapi.client.message.ShowMessageParams;
 import org.sonarsource.sonarlint.core.clientapi.client.progress.StartProgressParams;
 import org.sonarsource.sonarlint.core.clientapi.client.smartnotification.ShowSmartNotificationParams;
@@ -153,7 +153,6 @@ class SonarLintVSCodeClientTests {
   @Test
   void shouldHandleShowSmartNotificationWhenConnectionExists() {
     var workspaceSettings = mock(WorkspaceSettings.class);
-    var backendServiceFacade = mock(BackendServiceFacade.class);
     var showSmartNotificationParams = mock(ShowSmartNotificationParams.class);
     when(showSmartNotificationParams.getConnectionId()).thenReturn("testId");
     var serverConnections = Map.of("testId",
@@ -173,7 +172,6 @@ class SonarLintVSCodeClientTests {
   @Test
   void shouldHandleShowSmartNotificationWhenConnectionExistsForSonarCloud() {
     var workspaceSettings = mock(WorkspaceSettings.class);
-    var backendServiceFacade = mock(BackendServiceFacade.class);
     var showSmartNotificationParams = mock(ShowSmartNotificationParams.class);
     when(showSmartNotificationParams.getConnectionId()).thenReturn("testId");
     var serverConnections = Map.of("testId",
@@ -234,15 +232,15 @@ class SonarLintVSCodeClientTests {
 
   @Test
   void shouldCallServerOnGetHostInfo() {
-    underTest.getHostInfo();
+    underTest.getClientInfo();
     verify(server).getHostInfo();
   }
 
   @Test
   void shouldGetHostInfo() throws ExecutionException, InterruptedException {
     var desc = "This is Test";
-    when(server.getHostInfo()).thenReturn(new GetHostInfoResponse("This is Test"));
-    var result = underTest.getHostInfo().get();
+    when(server.getHostInfo()).thenReturn(new GetClientInfoResponse("This is Test"));
+    var result = underTest.getClientInfo().get();
     assertThat(result.getDescription()).isEqualTo(desc);
   }
 

--- a/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/LanguageServerMediumTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/LanguageServerMediumTests.java
@@ -785,7 +785,7 @@ class LanguageServerMediumTests extends AbstractLanguageServerMediumTests {
       .contains(
         "[Info] Analyzing file '" + uri + "'...",
         "[Info] Index files",
-        "[Debug] Language of file '" + uri + "' is set to 'Python'",
+        "[Debug] Language of file \"" + uri + "\" is set to \"Python\"",
         "[Info] 1 file indexed",
         "[Debug] Execute Sensor: Python Sensor",
         "[Info] Found 1 issue"));


### PR DESCRIPTION
The context action to mark an issue as Won’t Fix or False Positive is currently named “Resolve this issue violating rule 'XXX'“ 

Some user research revealed that this naming does not work well with users, and especially it leads them to think that activating this action will directly change the issue’s status: https://www.figma.com/file/zh6eXTtgtiLY7S68dRmETX/Open-issues-from-SC%2FSQ-to-IDE?type=whiteboard&node-id=0-1&t=6OqGvavCR2L8Hgcd-0 - Connect your Figma account 

I propose to rename the action “Mark issue violating rule 'XXX' as…“ similarly to what is already done in SLE