### PR TITLE
BUILD-4321 Ensure latest version of gh-action_release is used

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@582722e3a48525082240d4eaf69461ce158551da
     with:
       publishToBinaries: false
       mavenCentralSync: true


### PR DESCRIPTION
The action with `@v5` is triggering with
https://github.com/SonarSource/gh-action_release/commit/d78b7975dff4a9e4673579b5d5563cb6ac0c2184 which is missing the timeout.