### PR TITLE
SLLS-229 Move telemetry kill switch system property from core to language server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <jdk.min.version>17</jdk.min.version>
-    <sonarlint.core.version>10.0.1.77184</sonarlint.core.version>
+    <sonarlint.core.version>10.1.0.77276</sonarlint.core.version>
     <!-- Version used by Xodus -->
     <kotlin.version>1.6.10</kotlin.version>
     <!-- analyzers used for tests -->

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
@@ -303,12 +303,14 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
         .orElse(false);
       progressManager.setWorkDoneProgressSupportedByClient(workDoneSupportedByClient);
 
-      workspaceFoldersManager.initialize(params.getWorkspaceFolders());
-
       var options = Utils.parseToMap(params.getInitializationOptions());
       if (options == null) {
         options = Collections.emptyMap();
       }
+      var showVerboseLogs = (boolean) options.getOrDefault("showVerboseLogs", true);
+      lsLogOutput.initialize(showVerboseLogs);
+
+      workspaceFoldersManager.initialize(params.getWorkspaceFolders());
 
       var productKey = (String) options.get("productKey");
       // deprecated, will be ignored when productKey present
@@ -325,11 +327,9 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
       var platform = (String) options.get("platform");
       var architecture = (String) options.get("architecture");
       var additionalAttributes = (Map<String, Object>) options.getOrDefault("additionalAttributes", Map.of());
-      var showVerboseLogs = (boolean) options.getOrDefault("showVerboseLogs", true);
       var userAgent = productName + " " + productVersion;
       var clientNodePath = (String) options.get("clientNodePath");
 
-      lsLogOutput.initialize(showVerboseLogs);
       analysisScheduler.initialize();
       diagnosticPublisher.initialize(firstSecretDetected);
 

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
@@ -244,6 +244,7 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
       client, globalLogOutput, backendServiceFacade, openNotebooksCache);
     vsCodeClient.setBindingManager(bindingManager);
     this.telemetry = new SonarLintTelemetry(backendServiceFacade, globalLogOutput);
+    backendServiceFacade.setTelemetry(this.telemetry);
     this.settingsManager.addListener(telemetry);
     this.settingsManager.addListener((WorkspaceSettingsChangeListener) bindingManager);
     this.settingsManager.addListener((WorkspaceFolderSettingsChangeListener) bindingManager);

--- a/src/main/java/org/sonarsource/sonarlint/ls/backend/BackendServiceFacade.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/backend/BackendServiceFacade.java
@@ -51,6 +51,7 @@ import org.sonarsource.sonarlint.ls.SonarLintExtendedLanguageClient;
 import org.sonarsource.sonarlint.ls.log.LanguageClientLogger;
 import org.sonarsource.sonarlint.ls.settings.ServerConnectionSettings;
 import org.sonarsource.sonarlint.ls.settings.SettingsManager;
+import org.sonarsource.sonarlint.ls.telemetry.SonarLintTelemetry;
 import org.sonarsource.sonarlint.ls.telemetry.TelemetryInitParams;
 
 public class BackendServiceFacade {
@@ -66,6 +67,7 @@ public class BackendServiceFacade {
   private SettingsManager settingsManager;
   private TelemetryInitParams telemetryInitParams;
   private final CountDownLatch initLatch = new CountDownLatch(1);
+  private SonarLintTelemetry telemetry;
 
   public BackendServiceFacade(SonarLintRpcClientDelegate rpcClient, LanguageClientLogger lsLogOutput, SonarLintExtendedLanguageClient client) {
     this.lsLogOutput = lsLogOutput;
@@ -125,6 +127,7 @@ public class BackendServiceFacade {
   }
 
   private InitializeParams toInitParams(BackendInitParams initParams) {
+    var telemetryEnabled = telemetry != null && telemetry.enabled();
     return new InitializeParams(
       new ClientConstantInfoDto("Visual Studio Code", initParams.getUserAgent()),
       new TelemetryClientConstantAttributesDto(initParams.getTelemetryProductKey(),
@@ -135,7 +138,7 @@ public class BackendServiceFacade {
       getHttpConfiguration(),
       getSonarCloudAlternativeEnvironment(),
       new FeatureFlagsDto(true, true, true,
-        true, initParams.isEnableSecurityHotspots(), true, true, true),
+        true, initParams.isEnableSecurityHotspots(), true, true, true, telemetryEnabled),
       initParams.getStorageRoot(),
       Path.of(initParams.getSonarlintUserHome()),
       initParams.getEmbeddedPluginPaths(),
@@ -217,5 +220,9 @@ public class BackendServiceFacade {
 
   public CountDownLatch getInitLatch() {
     return initLatch;
+  }
+
+  public void setTelemetry(SonarLintTelemetry telemetry) {
+    this.telemetry = telemetry;
   }
 }

--- a/src/main/java/org/sonarsource/sonarlint/ls/telemetry/SonarLintTelemetry.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/telemetry/SonarLintTelemetry.java
@@ -61,7 +61,12 @@ public class SonarLintTelemetry implements WorkspaceSettingsChangeListener {
   }
 
   public boolean enabled() {
-    return !"true".equals(System.getProperty(DISABLE_PROPERTY_KEY));
+    var telemetrySystemPropertyOverride = System.getProperty(DISABLE_PROPERTY_KEY);
+    var telemetryDisabledBySystemProperty = "true".equals(telemetrySystemPropertyOverride);
+    if (telemetryDisabledBySystemProperty) {
+      logOutput.debug("Telemetry is disabled by system property");
+    }
+    return !telemetryDisabledBySystemProperty;
   }
 
   public void analysisDoneOnMultipleFiles() {


### PR DESCRIPTION
Note: this commit also has an updated core that should log details about why a configuration scope is not available for analysis.