### PR TITLE
SLVSCODE-729 Replace string concatenation with message formatting in log

### DIFF
--- a/src/main/java/org/sonarsource/sonarlint/ls/folders/WorkspaceFoldersManager.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/folders/WorkspaceFoldersManager.java
@@ -192,7 +192,7 @@ public class WorkspaceFoldersManager {
   }
 
   public void updateAnalysisReadiness(Set<String> configurationScopeIds, boolean areReadyForAnalysis) {
-    configurationScopeIds.forEach(s -> logOutput.debug("Analysis readiness changed for config scope " + s + " to " + areReadyForAnalysis));
+    configurationScopeIds.forEach(s -> logOutput.debug("Analysis readiness changed for config scope `%s` to %b", s, areReadyForAnalysis));
     configurationScopeIds.forEach(folderUri -> analysisReadiness.put(folderUri, areReadyForAnalysis));
   }
 


### PR DESCRIPTION
Since the URI can contain %-encoded characters, some end up clashing with string format sequences. At this point, an exception is thrown and the folder nevers becomes ready.