### PR TITLE
SLLS-235 Fix swapped certificate dates when prompting about untrusted certificate

### DIFF
--- a/src/main/java/org/sonarsource/sonarlint/ls/clientapi/SonarLintVSCodeClient.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/clientapi/SonarLintVSCodeClient.java
@@ -366,8 +366,8 @@ public class SonarLintVSCodeClient implements SonarLintRpcClientDelegate {
     var confirmationParams = new SonarLintExtendedLanguageClient.SslCertificateConfirmationParams(
       untrustedCert == null ? "" : untrustedCert.getSubjectX500Principal().getName(),
       untrustedCert == null ? "" : untrustedCert.getIssuerX500Principal().getName(),
-      untrustedCert == null ? "" : untrustedCert.getNotAfter().toString(),
       untrustedCert == null ? "" : untrustedCert.getNotBefore().toString(),
+      untrustedCert == null ? "" : untrustedCert.getNotAfter().toString(),
       sha1fingerprint,
       sha256fingerprint,
       actualSonarLintUserHome.toString()


### PR DESCRIPTION
The signature of `SslCertificateConfirmationParams` asks for `validFrom` and then `validTo`.

https://github.com/SonarSource/sonarlint-language-server/blob/675fb6944239e1c581c1494fa162d4ea90c4bb80/src/main/java/org/sonarsource/sonarlint/ls/SonarLintExtendedLanguageClient.java#L837-L838

When the VS Code client is prompting to trust an untrusted certificate, it's providing the parameters in the wrong order, `notAfter` (which should map to `validTo`), then `notBefore` (which should map to `validFrom`).

https://github.com/SonarSource/sonarlint-language-server/blob/675fb6944239e1c581c1494fa162d4ea90c4bb80/src/main/java/org/sonarsource/sonarlint/ls/clientapi/SonarLintVSCodeClient.java#L369-L370

As a result, the prompt reports a certificate that should not possibly exist, with a `validTo` after the `validFrom`.