### PR TITLE
SLLS-235 Fix swapped certificate dates when prompting about untrusted certificate

### DIFF
--- a/src/main/java/org/sonarsource/sonarlint/ls/clientapi/SonarLintVSCodeClient.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/clientapi/SonarLintVSCodeClient.java
@@ -366,8 +366,8 @@ public class SonarLintVSCodeClient implements SonarLintRpcClientDelegate {
     var confirmationParams = new SonarLintExtendedLanguageClient.SslCertificateConfirmationParams(
       untrustedCert == null ? "" : untrustedCert.getSubjectX500Principal().getName(),
       untrustedCert == null ? "" : untrustedCert.getIssuerX500Principal().getName(),
-      untrustedCert == null ? "" : untrustedCert.getNotAfter().toString(),
       untrustedCert == null ? "" : untrustedCert.getNotBefore().toString(),
+      untrustedCert == null ? "" : untrustedCert.getNotAfter().toString(),
       sha1fingerprint,
       sha256fingerprint,
       actualSonarLintUserHome.toString()


### PR DESCRIPTION
This is a duplicate of #350 to let the CI checks run.