### PR TITLE
Fix JsonNull conversion error

### DIFF
--- a/src/main/java/org/sonarsource/sonarlint/ls/ServerMain.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/ServerMain.java
@@ -20,20 +20,25 @@
 package org.sonarsource.sonarlint.ls;
 
 import com.google.common.collect.ImmutableList;
+
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.jar.Manifest;
+
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.IVersionProvider;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParameterException;
 import picocli.CommandLine.Parameters;
 import picocli.CommandLine.Spec;
 
-@Command
+@Command(versionProvider = ServerMain.MavenVersionProvider.class, mixinStandardHelpOptions = true)
 public class ServerMain implements Callable<Integer> {
 
   @Parameters(index = "0", description = "The port to which sonarlint should connect to.", defaultValue = "-1")
@@ -98,4 +103,14 @@ public class ServerMain implements Callable<Integer> {
     System.exit(exitCode);
   }
 
+  public static class MavenVersionProvider implements IVersionProvider {
+
+    @Override
+    public String[] getVersion() throws Exception {
+      try(InputStream is = getClass().getResourceAsStream("/META-INF/MANIFEST.MF")) {
+        Manifest mf = new Manifest(is);
+        return new String[] { mf.getMainAttributes().getValue("Implementation-Version") };
+      }
+    }
+  }
 }

--- a/src/main/java/org/sonarsource/sonarlint/ls/settings/SettingsManager.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/settings/SettingsManager.java
@@ -22,6 +22,7 @@ package org.sonarsource.sonarlint.ls.settings;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import java.net.URI;
@@ -267,7 +268,11 @@ public class SettingsManager implements WorkspaceFolderLifecycleListener {
         if (response != null) {
           var settingsMap = new HashMap<String, Object>();
           for (var i = 0; i < response.size(); i++) {
-            settingsMap.put(params.getItems().get(i).getSection(), response.get(i));
+            var value = response.get(i);
+            if (JsonNull.INSTANCE.equals(value)) {
+               continue;
+            }
+            settingsMap.put(params.getItems().get(i).getSection(), value);
           }
           if (!settingsMap.isEmpty()) {
             var updatedProperties = updateProperties(uri, settingsMap);


### PR DESCRIPTION
Some LSP clients do not send values outside of of configuration namespace. For example Neovim does not support sending client configurations to mimic the VScode behavior. Following in Lua is not possible.

```lua
require('sonarlint').setup({
   server = {
      cmd = {
         -- …
      },
      settings = {
         sonarlint = {
            -- …
         },
         ["files.exclude"] = { ["**/.git"] = true },
      }
   },
})
```

This commit makes sure that sonarlint language server still functions if the values won't be sent. Otherwise, the language server errors while loading the project.

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->
