### PR TITLE
Fix Build: Replace Unavailable Analyzers Versions With Available Ones From Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,10 @@
     <sonar.python.version>4.17.0.14845</sonar.python.version>
     <sonar.html.version>3.16.0.5274</sonar.html.version>
     <sonar.xml.version>2.10.0.4108</sonar.xml.version>
-    <sonar.text.version>2.18.0.4812</sonar.text.version>
+    <sonar.text.version>2.18.0.4866</sonar.text.version>
     <sonar.go.version>1.15.0.4655</sonar.go.version>
     <sonar.iac.version>1.27.0.9518</sonar.iac.version>
-    <sonar.csharp.version>10.2.0.103721</sonar.csharp.version>
+    <sonar.csharp.version>10.2.0.105762</sonar.csharp.version>
     <sonarlint.omnisharp.version>1.25.0.100242</sonarlint.omnisharp.version>
     <gitRepositoryName>sonarlint-language-server</gitRepositoryName>
     <!-- Release: enable publication to Bintray -->


### PR DESCRIPTION
It is currently not possible to build the sonarlint-language-server (at least with only maven central as the repository).

This pr fixes the following two errors:

```log
Unable to find/resolve artifact.: The following artifacts could not be resolved: org.sonarsource.text:sonar-text-plugin:jar:2.18.0.4812 (absent): org.sonarsource.text:sonar-text-plugin:jar:2.18.0.4812 was not found in https://repo.maven.apache.org/maven2

Unable to find/resolve artifact.: The following artifacts could not be resolved: org.sonarsource.dotnet:sonar-csharp-plugin:jar:10.2.0.103721 (absent): org.sonarsource.dotnet:sonar-csharp-plugin:jar:10.2.0.103721 was not found in https://repo.maven.apache.org/maven2
```

and makes the build pass again.