### PR TITLE
Fallback to window/showMessage

### DIFF
--- a/src/main/java/org/sonarsource/sonarlint/ls/SkippedPluginsNotifier.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SkippedPluginsNotifier.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.ShowMessageRequestParams;
 import org.sonarsource.sonarlint.core.plugin.commons.api.SkipReason;
@@ -79,6 +80,9 @@ public class SkippedPluginsNotifier {
     if (Boolean.TRUE.equals(isNotificationAllowed)) {
       showMessageWithOpenSettingsAction(client, formatMessage(title, content), NODEJS,
         client::openPathToNodeSettings);
+    }
+    else {
+      client.showMessage(new MessageParams(MessageType.Error, content));
     }
   }
 


### PR DESCRIPTION
When the node version is not available and the LSP client doesn't support the flow behind sonarlint/canShowMissingRequirementsNotification, then the LSP server falls back to window/showMessage to notify the LSP client at least.

This is relevant in the context of sonarlint.nvim, the Neovim plugin for sonarlint-language-server that I maintain, because in Neovim land there is no default place where you can edit the configuration. Thus, a notification is sufficient which look like this:

![Showing the notification of missing Node.js version in Neovim](https://github.com/user-attachments/assets/8f9b78ae-09b4-4c72-a1c6-fa580c5cc8d8)

See also [issue 29](https://gitlab.com/schrieveslaach/sonarlint.nvim/-/issues/29)