### PR TITLE
BUILD-8073 Migrate public repositories workflows to large runners

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestMerged_job:
     name: Pull Request Merged
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestCreated_job:
     name: Pull Request Created
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       id-token: write
     # For external PR, ticket should be created manually

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   RequestReview_job:
     name: Request review
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   SubmitReview_job:
     name: Submit Review
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -5,7 +5,7 @@ name: Releasability status
       - completed
 jobs:
   update_releasability_status:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     name: Releasability status
     permissions:
       id-token: write


### PR DESCRIPTION
[BUILD-8073](https://sonarsource.atlassian.net/browse/BUILD-8073)

Migrates public repository workflows from standard GitHub-hosted runners to **Large Runners**
(`ubuntu-latest` → `ubuntu-latest-large`, etc.).

See [BUILD-8073](https://sonarsource.atlassian.net/browse/BUILD-8073) for details.


[BUILD-8073]: https://sonarsource.atlassian.net/browse/BUILD-8073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ