### PR TITLE
SLLS-345 Fallback to window/showMessage

### DIFF
--- a/src/main/java/org/sonarsource/sonarlint/ls/SkippedPluginsNotifier.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SkippedPluginsNotifier.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.ShowMessageRequestParams;
 import org.sonarsource.sonarlint.core.plugin.commons.api.SkipReason;
@@ -79,6 +80,8 @@ public class SkippedPluginsNotifier {
     if (Boolean.TRUE.equals(isNotificationAllowed)) {
       showMessageWithOpenSettingsAction(client, formatMessage(title, content), NODEJS,
         client::openPathToNodeSettings);
+    } else {
+      client.showMessage(new MessageParams(MessageType.Error, content));
     }
   }
 


### PR DESCRIPTION
[SLLS-345](https://sonarsource.atlassian.net/browse/SLLS-345)

When the node version is not available and the LSP client doesn't support the flow behind sonarlint/canShowMissingRequirementsNotification, then the LSP server falls back to window/showMessage to notify the LSP client at least.

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->


[SLLS-345]: https://sonarsource.atlassian.net/browse/SLLS-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ