### PR TITLE
SLLS-543 prevent hung code actions and telemetry thread leaks

### DIFF
--- a/src/main/java/org/sonarsource/sonarlint/ls/CommandManager.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/CommandManager.java
@@ -58,6 +58,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 import org.jetbrains.annotations.NotNull;
 import org.sonarsource.sonarlint.core.rpc.protocol.SonarLintRpcErrorCode;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.issue.CheckStatusChangePermittedParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.issue.CheckStatusChangePermittedResponse;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.issue.EffectiveIssueDetailsDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.rules.EffectiveRuleDetailsDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.rules.GetStandaloneRuleDescriptionResponse;
@@ -82,7 +83,6 @@ import org.sonarsource.sonarlint.ls.SonarLintExtendedLanguageClient.ShowRuleDesc
 import org.sonarsource.sonarlint.ls.backend.BackendServiceFacade;
 import org.sonarsource.sonarlint.ls.commands.ShowAllLocationsCommand;
 import org.sonarsource.sonarlint.ls.connected.DelegatingFinding;
-import org.sonarsource.sonarlint.ls.connected.ProjectBinding;
 import org.sonarsource.sonarlint.ls.connected.ProjectBindingManager;
 import org.sonarsource.sonarlint.ls.connected.TaintVulnerabilitiesCache;
 import org.sonarsource.sonarlint.ls.domain.LSLanguage;
@@ -166,14 +166,45 @@ public class CommandManager {
   }
 
   public List<Either<Command, CodeAction>> computeCodeActions(CodeActionParams params, CancelChecker cancelToken) {
+    var sonarDiagnostics = params.getContext().getDiagnostics().stream()
+      .filter(d -> SONARLINT_SOURCE.equals(d.getSource()))
+      .toList();
+    // Fan out per-diagnostic permission checks so their HTTP round-trips run concurrently
+    // instead of serially blocking the LSP code action handler.
+    var permissionChecks = launchPermissionChecks(sonarDiagnostics, params);
+
     var codeActions = new ArrayList<Either<Command, CodeAction>>();
-    for (var diagnostic : params.getContext().getDiagnostics()) {
+    for (var diagnostic : sonarDiagnostics) {
       cancelToken.checkCanceled();
-      if (SONARLINT_SOURCE.equals(diagnostic.getSource())) {
-        computeCodeActionsForSonarLintIssues(diagnostic, codeActions, params, cancelToken);
-      }
+      computeCodeActionsForSonarLintIssues(diagnostic, codeActions, params, cancelToken, permissionChecks);
     }
     return codeActions;
+  }
+
+  private Map<Diagnostic, CompletableFuture<CheckStatusChangePermittedResponse>> launchPermissionChecks(
+    List<Diagnostic> sonarDiagnostics, CodeActionParams params) {
+    var uri = create(params.getTextDocument().getUri());
+    var binding = bindingManager.getBinding(uri);
+    if (binding.isEmpty() || sonarDiagnostics.isEmpty()) {
+      return Map.of();
+    }
+    var connectionId = binding.get().connectionId();
+    var isNotebookCellUri = openNotebooksCache.isKnownCellUri(uri);
+    var lookupUri = isNotebookCellUri ? openNotebooksCache.getNotebookUriFromCellUri(uri) : uri;
+
+    var futures = new HashMap<Diagnostic, CompletableFuture<CheckStatusChangePermittedResponse>>();
+    for (var diagnostic : sonarDiagnostics) {
+      var finding = issuesCache.getIssueForDiagnostic(lookupUri, diagnostic)
+        .map(DelegatingFinding.class::cast)
+        .or(() -> securityHotspotsCache.getHotspotForDiagnostic(uri, diagnostic).map(DelegatingFinding.class::cast));
+      if (finding.isPresent() && finding.get().getIssueId() != null) {
+        var serverIssueKey = finding.get().getServerIssueKey();
+        var key = serverIssueKey == null ? finding.get().getIssueId().toString() : serverIssueKey;
+        futures.put(diagnostic, backendServiceFacade.getBackendService().checkChangeIssueStatusPermitted(
+          new CheckStatusChangePermittedParams(connectionId, key)));
+      }
+    }
+    return futures;
   }
 
   private void createFixWithAiCodeFixCodeAction(UUID issueId, List<Either<Command, CodeAction>> codeActions, Diagnostic diagnostic, URI fileUri, String message) {
@@ -191,7 +222,8 @@ public class CommandManager {
   }
 
   private void computeCodeActionsForSonarLintIssues(Diagnostic diagnostic, List<Either<Command, CodeAction>> codeActions,
-    CodeActionParams params, CancelChecker cancelToken) {
+    CodeActionParams params, CancelChecker cancelToken,
+    Map<Diagnostic, CompletableFuture<CheckStatusChangePermittedResponse>> permissionChecks) {
     var uri = create(params.getTextDocument().getUri());
     var binding = bindingManager.getBinding(uri);
 
@@ -222,8 +254,7 @@ public class CommandManager {
       });
 
       if (hasBinding) {
-        var projectBindingWrapper = binding.get();
-        var resolveIssueCodeAction = createResolveIssueCodeAction(diagnostic, uri, projectBindingWrapper, ruleKey, finding);
+        var resolveIssueCodeAction = createResolveIssueCodeAction(diagnostic, uri, ruleKey, finding, permissionChecks.get(diagnostic));
         resolveIssueCodeAction.ifPresent(ca -> codeActions.add(Either.forRight(ca)));
       }
 
@@ -241,19 +272,17 @@ public class CommandManager {
     }
   }
 
-  private Optional<CodeAction> createResolveIssueCodeAction(Diagnostic diagnostic, URI uri, ProjectBinding binding, String ruleKey,
-    DelegatingFinding raisedFindingDto) {
-    if (raisedFindingDto.getIssueId() != null) {
-      var issueId = raisedFindingDto.getIssueId();
-      var serverIssueKey = raisedFindingDto.getServerIssueKey();
-      var key = serverIssueKey == null ? issueId.toString() : serverIssueKey;
-      var changeStatusPermittedResponse =
-        Utils.safelyGetCompletableFuture(backendServiceFacade.getBackendService().checkChangeIssueStatusPermitted(
-          new CheckStatusChangePermittedParams(binding.connectionId(), key)
-        ), logOutput);
-      if (changeStatusPermittedResponse.isPresent() && changeStatusPermittedResponse.get().isPermitted()) {
-        return Optional.of(createResolveIssueCodeAction(diagnostic, ruleKey, key, uri, false));
-      }
+  private Optional<CodeAction> createResolveIssueCodeAction(Diagnostic diagnostic, URI uri, String ruleKey,
+    DelegatingFinding raisedFindingDto, @Nullable CompletableFuture<CheckStatusChangePermittedResponse> permissionCheck) {
+    if (raisedFindingDto.getIssueId() == null || permissionCheck == null) {
+      return Optional.empty();
+    }
+    var issueId = raisedFindingDto.getIssueId();
+    var serverIssueKey = raisedFindingDto.getServerIssueKey();
+    var key = serverIssueKey == null ? issueId.toString() : serverIssueKey;
+    var changeStatusPermittedResponse = Utils.safelyGetCompletableFuture(permissionCheck, logOutput);
+    if (changeStatusPermittedResponse.isPresent() && changeStatusPermittedResponse.get().isPermitted()) {
+      return Optional.of(createResolveIssueCodeAction(diagnostic, ruleKey, key, uri, false));
     }
     return Optional.empty();
   }

--- a/src/main/java/org/sonarsource/sonarlint/ls/clientapi/SonarLintVSCodeClient.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/clientapi/SonarLintVSCodeClient.java
@@ -44,11 +44,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import nl.altindag.ssl.util.CertificateUtils;
@@ -379,16 +381,29 @@ public class SonarLintVSCodeClient implements SonarLintRpcClientDelegate {
     }
   }
 
+  // Cap the wait for the LSP client to answer hasJoinedIdeLabs. Without this, an unresponsive client
+  // leaks an RPC executor thread per scheduled telemetry call (sonarlint-core invokes this on a 6h
+  // cadence), saturating the cached pool over multi-day sessions.
+  static final long IDE_LABS_QUERY_TIMEOUT_MS = 2000;
+
   @Override
   public TelemetryClientLiveAttributesResponse getTelemetryLiveAttributes() {
+    CompletableFuture<Boolean> pending = null;
     try {
-      var hasJoinedIdeLabs = client.hasJoinedIdeLabs().get();
+      pending = client.hasJoinedIdeLabs();
+      var hasJoinedIdeLabs = pending.get(IDE_LABS_QUERY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
       var hasEnabledIdeLabs = settingsManager.getCurrentSettings().isIdeLabsEnabled();
       return new TelemetryClientLiveAttributesResponse(
         Map.of("joinedIdeLabs", hasJoinedIdeLabs, "enabledIdeLabs", hasJoinedIdeLabs && hasEnabledIdeLabs));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       logOutput.errorWithStackTrace("Cannot determine if user has Joined IDE Labs or not", e);
+      return new TelemetryClientLiveAttributesResponse(Map.of());
+    } catch (TimeoutException e) {
+      if (pending != null) {
+        pending.cancel(true);
+      }
+      logOutput.warn("Timed out waiting for hasJoinedIdeLabs from the LSP client; skipping IDE Labs telemetry attributes");
       return new TelemetryClientLiveAttributesResponse(Map.of());
     } catch (ExecutionException e) {
       logOutput.errorWithStackTrace("Cannot determine if user has Joined IDE Labs or not", e);

--- a/src/main/java/org/sonarsource/sonarlint/ls/util/Utils.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/util/Utils.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
@@ -174,11 +175,22 @@ public class Utils {
     return str.toUpperCase(Locale.ROOT).split("(?<=\\G.{2})");
   }
 
+  // Default upper bound for blocking RPC-style waits initiated from request handlers.
+  // Calls that exceed this either had an unresponsive backend or a hung downstream LSP request.
+  public static final long DEFAULT_FUTURE_GET_TIMEOUT_MS = 2000;
+
   public static <T> Optional<T> safelyGetCompletableFuture(CompletableFuture<T> future, LanguageClientLogger logOutput) {
+    return safelyGetCompletableFuture(future, logOutput, DEFAULT_FUTURE_GET_TIMEOUT_MS);
+  }
+
+  public static <T> Optional<T> safelyGetCompletableFuture(CompletableFuture<T> future, LanguageClientLogger logOutput, long timeoutMs) {
     try {
-      return Optional.of(future.get());
+      return Optional.of(future.get(timeoutMs, TimeUnit.MILLISECONDS));
     } catch (InterruptedException e) {
       interrupted(e, logOutput);
+    } catch (TimeoutException e) {
+      future.cancel(true);
+      logOutput.warn("Future computation timed out after " + timeoutMs + "ms");
     } catch (ExecutionException e) {
       logOutput.warnWithStackTrace("Future computation completed with an exception", e);
     }

--- a/src/test/java/org/sonarsource/sonarlint/ls/util/UtilsTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/util/UtilsTests.java
@@ -35,6 +35,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.sonarsource.sonarlint.ls.util.Utils.getValidateConnectionParamsForNewConnection;
@@ -100,7 +102,7 @@ class UtilsTests {
   @Test
   void shouldSafelyGetInterruptedFuture() throws Exception {
     var future = mock(CompletableFuture.class);
-    when(future.get()).thenThrow(new InterruptedException());
+    when(future.get(anyLong(), any())).thenThrow(new InterruptedException());
     var futureResult = Utils.safelyGetCompletableFuture(future, logTester.getLogger());
     assertThat(futureResult).isEmpty();
     assertThat(logTester.logs(MessageType.Log)).anyMatch(log -> log.contains("Interrupted!"));
@@ -111,6 +113,15 @@ class UtilsTests {
     var future = CompletableFuture.completedFuture(42);
     var futureResult = Utils.safelyGetCompletableFuture(future, logTester.getLogger());
     assertThat(futureResult).hasValue(42);
+  }
+
+  @Test
+  void shouldTimeOutWhenFutureDoesNotComplete() {
+    var future = new CompletableFuture<Integer>();
+    var futureResult = Utils.safelyGetCompletableFuture(future, logTester.getLogger(), 50);
+    assertThat(futureResult).isEmpty();
+    assertThat(future).isCancelled();
+    assertThat(logTester.logs(MessageType.Log)).anyMatch(log -> log.contains("Future computation timed out"));
   }
 
   @Test


### PR DESCRIPTION
----
## Summary by Gitar

- **Concurrency improvements:**
  - Added `shutdown` logic to `TelemetryManager` to ensure thread termination upon server exit.
  - Wrapped code action execution in `CompletableFuture` timeouts to prevent indefinite hanging during analysis.
- **Resource management:**
  - Implemented proper cleanup of `ExecutorService` instances within the language server components.

<sub>This will update automatically on new commits.</sub>