### PR TITLE
SLLS-560 Support the Rust language in connected mode

### DIFF
--- a/src/main/java/org/sonarsource/sonarlint/ls/EnabledLanguages.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/EnabledLanguages.java
@@ -70,6 +70,7 @@ public class EnabledLanguages {
     Language.AZUREPIPELINES,
     Language.COBOL,
     Language.PLSQL,
+    Language.RUST,
     Language.SHELL,
     Language.TSQL,
     Language.ANSIBLE,

--- a/src/main/java/org/sonarsource/sonarlint/ls/domain/LSLanguage.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/domain/LSLanguage.java
@@ -54,6 +54,7 @@ public enum LSLanguage {
   PYTHON("Python", "py"),
   RPG("RPG", "rpg"),
   RUBY("Ruby", "ruby"),
+  RUST("Rust", "rust"),
   SCALA("Scala", "scala"),
   SECRETS("Secrets", "secrets"),
   SHELL("Shell", "shell"),

--- a/src/test/java/org/sonarsource/sonarlint/ls/domain/LSLanguageTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/domain/LSLanguageTests.java
@@ -66,6 +66,7 @@ class LSLanguageTests {
       Arguments.of(Language.PYTHON, "Python", "py"),
       Arguments.of(Language.RPG, "RPG", "rpg"),
       Arguments.of(Language.RUBY, "Ruby", "ruby"),
+      Arguments.of(Language.RUST, "Rust", "rust"),
       Arguments.of(Language.SCALA, "Scala", "scala"),
       Arguments.of(Language.SECRETS, "Secrets", "secrets"),
       Arguments.of(Language.SHELL, "Shell", "shell"),

--- a/src/test/java/org/sonarsource/sonarlint/ls/folders/ModuleEventsProcessorTest.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/folders/ModuleEventsProcessorTest.java
@@ -155,6 +155,7 @@ class ModuleEventsProcessorTest {
       Arguments.of("java", Language.JAVA),
       Arguments.of("c", Language.C),
       Arguments.of("cpp", Language.CPP),
+      Arguments.of("rust", Language.RUST),
       Arguments.of("shellscript", Language.SHELL),
 
       Arguments.of("yaml", Language.YAML),

--- a/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/ConnectedModeMediumTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/ConnectedModeMediumTests.java
@@ -94,7 +94,7 @@ class ConnectedModeMediumTests extends AbstractLanguageServerMediumTests {
   private static final String PYTHON_S1481 = "python:S1481";
   private static final String PYTHON_S1313 = "python:S1313";
   private static final String PROJECT_KEY = "myProject";
-  public static final String LANGUAGES_LIST = "apex,c,cpp,cs,css,cobol,web,java,js,php,plsql,py,secrets,text,tsql,ts,xml,yaml,json,go,cloudformation,docker,kubernetes,terraform," +
+  public static final String LANGUAGES_LIST = "apex,c,cpp,cs,css,cobol,web,java,js,php,plsql,py,rust,secrets,text,tsql,ts,xml,yaml,json,go,cloudformation,docker,kubernetes,terraform," +
     "azureresourcemanager,ansible,githubactions,shell,azurepipelines";
 
   @RegisterExtension


### PR DESCRIPTION
----
## Summary by Gitar

- **Language Support:**
  - Added `Language.RUST` to `EnabledLanguages` and `LSLanguage` enum.
  - Included `rust` in `LANGUAGES_LIST` for `ConnectedModeMediumTests` and updated language processing tests.

<sub>This will update automatically on new commits.</sub>