### PR TITLE
SLLS-568 Add missing ANSIBLE, JCL and RUST constants to LSLanguage

### DIFF
--- a/src/main/java/org/sonarsource/sonarlint/ls/domain/LSLanguage.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/domain/LSLanguage.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 
 public enum LSLanguage {
   ABAP("ABAP", "abap"),
+  ANSIBLE("Ansible", "ansible"),
   APEX("Apex", "apex"),
   AZUREPIPELINES("Azure Pipelines", "azurepipelines"),
   AZURERESOURCEMANAGER("AzureResourceManager", "azureresourcemanager"),
@@ -42,6 +43,7 @@ public enum LSLanguage {
   HTML("HTML", "web"),
   IPYTHON("IPython Notebooks", "ipynb"),
   JAVA("Java", "java"),
+  JCL("JCL", "jcl"),
   JS("JavaScript", "js"),
   JSON("JSON", "json"),
   JSP("JSP", "jsp"),
@@ -54,6 +56,7 @@ public enum LSLanguage {
   PYTHON("Python", "py"),
   RPG("RPG", "rpg"),
   RUBY("Ruby", "ruby"),
+  RUST("Rust", "rust"),
   SCALA("Scala", "scala"),
   SECRETS("Secrets", "secrets"),
   SHELL("Shell", "shell"),

--- a/src/test/java/org/sonarsource/sonarlint/ls/domain/LSLanguageTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/domain/LSLanguageTests.java
@@ -19,15 +19,35 @@
  */
 package org.sonarsource.sonarlint.ls.domain;
 
+import java.util.Arrays;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Language;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThatCode;
 
 class LSLanguageTests {
+
+  /**
+   * {@link LSLanguage} mirrors {@link Language} by name: every mapping site calls
+   * {@code LSLanguage.valueOf(language.name())}, so a language added to the backend without a
+   * counterpart here throws IllegalArgumentException at runtime.
+   */
+  @Test
+  void shouldMirrorEveryBackendLanguage() {
+    assertThatCode(() -> Arrays.stream(Language.values()).forEach(language -> LSLanguage.valueOf(language.name())))
+      .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldNotDeclareUnknownLanguages() {
+    assertThatCode(() -> Arrays.stream(LSLanguage.values()).forEach(lsLanguage -> Language.valueOf(lsLanguage.name())))
+      .doesNotThrowAnyException();
+  }
 
   @ParameterizedTest
   @MethodSource("shouldHaveMappingForLabelAndKey")
@@ -39,6 +59,7 @@ class LSLanguageTests {
   private static Stream<Arguments> shouldHaveMappingForLabelAndKey() {
     return Stream.of(
       Arguments.of(Language.ABAP, "ABAP", "abap"),
+      Arguments.of(Language.ANSIBLE, "Ansible", "ansible"),
       Arguments.of(Language.APEX, "Apex", "apex"),
       Arguments.of(Language.AZUREPIPELINES, "Azure Pipelines", "azurepipelines"),
       Arguments.of(Language.AZURERESOURCEMANAGER, "AzureResourceManager", "azureresourcemanager"),
@@ -54,6 +75,7 @@ class LSLanguageTests {
       Arguments.of(Language.HTML, "HTML", "web"),
       Arguments.of(Language.IPYTHON, "IPython Notebooks", "ipynb"),
       Arguments.of(Language.JAVA, "Java", "java"),
+      Arguments.of(Language.JCL, "JCL", "jcl"),
       Arguments.of(Language.JS, "JavaScript", "js"),
       Arguments.of(Language.JSON, "JSON", "json"),
       Arguments.of(Language.JSP, "JSP", "jsp"),
@@ -66,6 +88,7 @@ class LSLanguageTests {
       Arguments.of(Language.PYTHON, "Python", "py"),
       Arguments.of(Language.RPG, "RPG", "rpg"),
       Arguments.of(Language.RUBY, "Ruby", "ruby"),
+      Arguments.of(Language.RUST, "Rust", "rust"),
       Arguments.of(Language.SCALA, "Scala", "scala"),
       Arguments.of(Language.SECRETS, "Secrets", "secrets"),
       Arguments.of(Language.SHELL, "Shell", "shell"),


### PR DESCRIPTION
`LSLanguage` mirrors the backend `Language` enum by name, and every mapping site calls `LSLanguage.valueOf(language.name())`. A language supported by the backend but absent from `LSLanguage` therefore throws `IllegalArgumentException` at runtime.

The visible symptom is that the rule description panel never opens for a finding in such a language. `CommandManager` catches the failure in `.exceptionally` and surfaces a misleading *"Can't show issue details for unknown rule"* message, so the real cause only shows up in the log.

`ANSIBLE` was reachable in practice: it is declared in `EnabledLanguages.CONNECTED_ADDITIONAL_LANGUAGES`, so in connected mode against SonarQube Cloud or a paid SonarQube Server edition the enterprise IaC analyzer raises Ansible findings that the client then cannot map. `JCL` and `RUST` were missing too, and are added for consistency.

Labels and keys come from `SonarLanguage` in sonarlint-core.

## Tests

Adds two guard tests asserting the enums stay in sync in both directions, so a future backend addition fails the build instead of the IDE. Verified they catch the drift: removing `ANSIBLE` again reproduces `No enum constant ...LSLanguage.ANSIBLE`.

Manually validated in SonarQube for VS Code in connected mode — the rule description panel now opens for an `ansible:` finding.

<img width="979" height="327" alt="Screenshot 2026-07-27 at 14 21 29" src="https://github.com/user-attachments/assets/4bb96c67-871e-41bf-a0b7-81a88385ecd4" />