### PR TITLE
SLLS-575 Stop declaring deprecated CONTEXT_GENERATION backend capability

### DIFF
--- a/src/main/java/org/sonarsource/sonarlint/ls/backend/BackendServiceFacade.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/backend/BackendServiceFacade.java
@@ -185,7 +185,7 @@ public class BackendServiceFacade {
     var backendCapabilities = EnumSet.of(BackendCapability.SMART_NOTIFICATIONS, BackendCapability.PROJECT_SYNCHRONIZATION,
       BackendCapability.EMBEDDED_SERVER, BackendCapability.SERVER_SENT_EVENTS, BackendCapability.DATAFLOW_BUG_DETECTION,
       BackendCapability.FULL_SYNCHRONIZATION, BackendCapability.SECURITY_HOTSPOTS, BackendCapability.ISSUE_STREAMING,
-      BackendCapability.SCA_SYNCHRONIZATION, BackendCapability.CONTEXT_GENERATION, BackendCapability.GESSIE_TELEMETRY, BackendCapability.PROMOTIONAL_CAMPAIGNS);
+      BackendCapability.SCA_SYNCHRONIZATION, BackendCapability.GESSIE_TELEMETRY, BackendCapability.PROMOTIONAL_CAMPAIGNS);
     if (telemetry != null && telemetry.enabled()) {
       backendCapabilities.add(BackendCapability.TELEMETRY);
     }


### PR DESCRIPTION
## Summary
- Remove `BackendCapability.CONTEXT_GENERATION` from backend initialization capabilities.
- Follow-up to the SonarCodeContext removal / capability deprecation in sonarlint-core ([SLCORE-2540](https://sonarsource.atlassian.net/browse/SLCORE-2540)).

## Test plan
- [ ] Confirm language server still initializes the backend successfully
- [ ] Smoke-check analysis / connected mode still works in VS Code

[SLCORE-2540]: https://sonarsource.atlassian.net/browse/SLCORE-2540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ