### PR TITLE
Bump sonarlint-core to 11.10.0.86211 to fix jackson-databind CVE-2026-83557

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <jdk.min.version>17</jdk.min.version>
-    <sonarlint.core.version>11.9.0.86162</sonarlint.core.version>
+    <sonarlint.core.version>11.10.0.86211</sonarlint.core.version>
     <slf4j.version>2.0.17</slf4j.version>
     <!-- Version used by Xodus -->
     <kotlin.version>1.9.21</kotlin.version>


### PR DESCRIPTION
## Summary
- Bumps `sonarlint.core.version` in `pom.xml` from `11.9.0.86162` to `11.10.0.86211` (unreleased master version).
- This transitively upgrades `com.fasterxml.jackson.core:jackson-databind` from the vulnerable `2.22.1` to `2.22.2`, fixing CVE-2026-83557 (Deserialization of Untrusted Data).