### PR TITLE
SLLS-584 Add RUST to connected-mode-only languages

### DIFF
--- a/src/main/java/org/sonarsource/sonarlint/ls/EnabledLanguages.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/EnabledLanguages.java
@@ -74,7 +74,8 @@ public class EnabledLanguages {
     Language.TSQL,
     Language.ANSIBLE,
     Language.TEXT,
-    Language.GITHUBACTIONS
+    Language.GITHUBACTIONS,
+    Language.RUST
   );
 
 

--- a/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/ConnectedModeMediumTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/mediumtests/ConnectedModeMediumTests.java
@@ -94,7 +94,7 @@ class ConnectedModeMediumTests extends AbstractLanguageServerMediumTests {
   private static final String PYTHON_S1481 = "python:S1481";
   private static final String PYTHON_S1313 = "python:S1313";
   private static final String PROJECT_KEY = "myProject";
-  public static final String LANGUAGES_LIST = "apex,c,cpp,cs,css,cobol,web,java,js,php,plsql,py,secrets,text,tsql,ts,xml,yaml,json,go,cloudformation,docker,kubernetes,terraform," +
+  public static final String LANGUAGES_LIST = "apex,c,cpp,cs,css,cobol,web,java,js,php,plsql,py,rust,secrets,text,tsql,ts,xml,yaml,json,go,cloudformation,docker,kubernetes,terraform," +
     "azureresourcemanager,ansible,githubactions,shell,azurepipelines";
 
   @RegisterExtension


### PR DESCRIPTION
Rust is already supported server-side (sonarlint-core enums, plugin manifest) but missing from `CONNECTED_ADDITIONAL_LANGUAGES`, so connected-mode sync never requests Rust rules.

SLLS-584, related: RUST-10, SLCORE-2485