### PR TITLE
Report Devin (rebranded Windsurf) as Windsurf IDE name for AI agent hooks

### DIFF
--- a/src/main/java/org/sonarsource/sonarlint/ls/backend/BackendServiceFacade.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/backend/BackendServiceFacade.java
@@ -171,13 +171,14 @@ public final class BackendServiceFacade {
   }
 
   static String determineProductKey(String appName, String clientProductKey) {
-    if (appName.toLowerCase(Locale.ROOT).contains(CURSOR_APP_NAME.toLowerCase(Locale.ROOT))) {
+    var lowerCaseAppName = appName.toLowerCase(Locale.ROOT);
+    if (lowerCaseAppName.contains(CURSOR_APP_NAME.toLowerCase(Locale.ROOT))) {
       return CURSOR_APP_NAME.toLowerCase(Locale.ROOT);
     }
-    if (appName.toLowerCase(Locale.ROOT).contains(WINDSURF_APP_NAME.toLowerCase(Locale.ROOT))) {
+    if (lowerCaseAppName.contains(WINDSURF_APP_NAME.toLowerCase(Locale.ROOT)) || lowerCaseAppName.contains(DEVIN_APP_NAME.toLowerCase(Locale.ROOT))) {
       return WINDSURF_APP_NAME.toLowerCase(Locale.ROOT);
     }
-    if (appName.toLowerCase(Locale.ROOT).contains(KIRO_APP_NAME.toLowerCase(Locale.ROOT))) {
+    if (lowerCaseAppName.contains(KIRO_APP_NAME.toLowerCase(Locale.ROOT))) {
       return KIRO_APP_NAME.toLowerCase(Locale.ROOT);
     }
     return clientProductKey;

--- a/src/main/java/org/sonarsource/sonarlint/ls/backend/BackendServiceFacade.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/backend/BackendServiceFacade.java
@@ -164,7 +164,7 @@ public final class BackendServiceFacade {
     if (lowerCaseAppName.contains(WINDSURF_APP_NAME.toLowerCase(Locale.ROOT)) || lowerCaseAppName.contains(DEVIN_APP_NAME.toLowerCase(Locale.ROOT))) {
       return WINDSURF_APP_NAME;
     }
-    if (appName.toLowerCase(Locale.ROOT).contains(KIRO_APP_NAME.toLowerCase(Locale.ROOT))) {
+    if (lowerCaseAppName.contains(KIRO_APP_NAME.toLowerCase(Locale.ROOT))) {
       return KIRO_APP_NAME;
     }
     return VSCODE_APP_NAME;

--- a/src/main/java/org/sonarsource/sonarlint/ls/backend/BackendServiceFacade.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/backend/BackendServiceFacade.java
@@ -71,6 +71,7 @@ public final class BackendServiceFacade {
 
   private static final String CURSOR_APP_NAME = "Cursor";
   private static final String WINDSURF_APP_NAME = "Windsurf";
+  private static final String DEVIN_APP_NAME = "Devin";
   private static final String KIRO_APP_NAME = "Kiro";
   private static final String VSCODE_APP_NAME = "Visual Studio Code";
 
@@ -155,10 +156,12 @@ public final class BackendServiceFacade {
   }
 
   static String determineIdeName(String appName) {
-    if (appName.toLowerCase(Locale.ROOT).contains(CURSOR_APP_NAME.toLowerCase(Locale.ROOT))) {
+    var lowerCaseAppName = appName.toLowerCase(Locale.ROOT);
+    if (lowerCaseAppName.contains(CURSOR_APP_NAME.toLowerCase(Locale.ROOT))) {
       return CURSOR_APP_NAME;
     }
-    if (appName.toLowerCase(Locale.ROOT).contains(WINDSURF_APP_NAME.toLowerCase(Locale.ROOT))) {
+    // Windsurf was rebranded to Devin; keep reporting "Windsurf" so the AI hook scripts and config layout stay compatible
+    if (lowerCaseAppName.contains(WINDSURF_APP_NAME.toLowerCase(Locale.ROOT)) || lowerCaseAppName.contains(DEVIN_APP_NAME.toLowerCase(Locale.ROOT))) {
       return WINDSURF_APP_NAME;
     }
     if (appName.toLowerCase(Locale.ROOT).contains(KIRO_APP_NAME.toLowerCase(Locale.ROOT))) {

--- a/src/test/java/org/sonarsource/sonarlint/ls/backend/BackendServiceFacadeTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/backend/BackendServiceFacadeTests.java
@@ -166,6 +166,13 @@ class BackendServiceFacadeTests {
   }
 
   @Test
+  void should_use_windsurf_as_product_key_for_devin_rebranded_windsurf() {
+    var productKey = BackendServiceFacade.determineProductKey("Devin", "vscode");
+
+    assertThat(productKey).isEqualTo("windsurf");
+  }
+
+  @Test
   void should_use_kiro_as_product_key_if_present_in_app_name() {
     var productKey = BackendServiceFacade.determineProductKey("Kiro", null);
 

--- a/src/test/java/org/sonarsource/sonarlint/ls/backend/BackendServiceFacadeTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/backend/BackendServiceFacadeTests.java
@@ -201,6 +201,20 @@ class BackendServiceFacadeTests {
   }
 
   @Test
+  void should_return_windsurf_as_ide_name_for_devin_rebranded_windsurf() {
+    var ideName = BackendServiceFacade.determineIdeName("Devin");
+
+    assertThat(ideName).isEqualTo("Windsurf");
+  }
+
+  @Test
+  void should_return_windsurf_as_ide_name_when_devin_contained_in_app_name() {
+    var ideName = BackendServiceFacade.determineIdeName("Devin Next");
+
+    assertThat(ideName).isEqualTo("Windsurf");
+  }
+
+  @Test
   void should_return_kiro_as_ide_name_if_present_in_app_name() {
     var ideName = BackendServiceFacade.determineIdeName("kiro");
 


### PR DESCRIPTION
Part of 

> **Note: this fix spans two repositories.** This PR makes the language server report the Windsurf IDE name on Devin so the AI-agent hook can find the backend. The companion change in `sonarlint-vscode` restores the AI Agents Configuration view (detection of the `Devin` app name): https://github.com/SonarSource/sonarlint-vscode/pull/1127 (opened as a separate PR; both should land together).

### Motivation

Windsurf IDE has been rebranded to **Devin** (Cognition); the LSP `clientInfo.name` is now `"Devin"`. `BackendServiceFacade.determineIdeName()` only recognizes `cursor` / `windsurf` / `kiro`, so on Devin the backend is initialized with `ideName = "Visual Studio Code"`.

This breaks the AI-agent hook: the script generated by sonarlint-core (`AiHookService.getIdeName(WINDSURF)` → `"Windsurf"`) scans ports 64120–64130 and only accepts a backend whose `/sonarlint/api/status` reports `ideName == "Windsurf"`. On Devin it never matches and exits with `Backend not found`, even though the IDE still uses the Windsurf configuration layout (`~/.codeium/windsurf[-next]/hooks.json`, `mcp_config.json`, `.windsurf/rules` — see https://docs.devin.ai/desktop/cascade/hooks).

### Change

`determineIdeName`: an app name containing `devin` now maps to `WINDSURF_APP_NAME`, alongside `windsurf`:

```java
if (lowerCaseAppName.contains("windsurf") || lowerCaseAppName.contains("devin")) {
  return WINDSURF_APP_NAME;
}
```

`determineProductKey` (telemetry) is intentionally left unchanged — happy to align it if you prefer Devin to report the `windsurf` product key too.

### Tests

Added `should_return_windsurf_as_ide_name_for_devin_rebranded_windsurf` and `should_return_windsurf_as_ide_name_when_devin_contained_in_app_name` in `BackendServiceFacadeTests`. `mvn test -Dtest=BackendServiceFacadeTests` → 20 tests, 0 failures (run locally against sonarlint-core 11.9.0.86162, since the pinned 11.10 build is only on repox).